### PR TITLE
Add build.lisp and Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .fasl
 .FASL
 __pycache__
+system-index.txt
+lisp-chat

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+SBCL_CMD := sbcl --noinform --disable-debugger --load
+OBJECTS := lisp-inference
+
+
+all: $(OBJECTS)
+
+
+$(OBJECTS): src/*.lisp
+	$(SBCL_CMD) build.lisp

--- a/build.lisp
+++ b/build.lisp
@@ -1,12 +1,13 @@
-(pushnew (truename (sb-unix:posix-getcwd/)) ql:*local-project-directories*)
-(ql:register-local-projects)
-(ql:quickload '(:lisp-chat :cffi))
+(defparameter *compression* 9 "Compression level of the executable binary.")
+(defparameter *debug* nil "Debug information")
 
-(eval-when (:compile-toplevel :execute)
-    (defconstant +debug+ nil))
+(eval-when (:execute)
+  (pushnew (truename (sb-unix:posix-getcwd/)) ql:*local-project-directories*)
+  (ql:register-local-projects)
+  (ql:quickload '(:lisp-chat :cffi)))
 
 (defmacro debug-format (&rest body)
-  (when +debug+
+  (when *debug*
     `(format t ,@body)))
 
 (defun import-foreign-libraries ()
@@ -25,11 +26,12 @@
   (import-foreign-libraries)
   (lisp-chat-client:main))
 
-;; close currently foreign libraries loaded
-(loop for library in (cffi:list-foreign-libraries :loaded-only t)
-      do (cffi:close-foreign-library library))
 
-(sb-ext:save-lisp-and-die "lisp-chat"
-                          :toplevel #'main
-                          :executable t
-                          :compression 1)
+(eval-when (:execute)
+  ;; close currently foreign libraries loaded
+  (loop for library in (cffi:list-foreign-libraries :loaded-only t)
+        do (cffi:close-foreign-library library))
+  (sb-ext:save-lisp-and-die "lisp-chat"
+                            :toplevel #'main
+                            :executable t
+                            :compression *compression*))

--- a/build.lisp
+++ b/build.lisp
@@ -1,0 +1,7 @@
+(pushnew (truename (sb-unix:posix-getcwd/)) ql:*local-project-directories* )
+(ql:register-local-projects)
+(ql:quickload :lisp-chat)
+(sb-ext:save-lisp-and-die "lisp-chat"
+                          :toplevel #'lisp-chat-client:main
+                          :executable t
+                          :compression 9)

--- a/build.lisp
+++ b/build.lisp
@@ -2,15 +2,27 @@
 (ql:register-local-projects)
 (ql:quickload '(:lisp-chat :cffi))
 
-(defun main()
-  (let ((libpath (sb-posix:getcwd)))
-    (format t "=> New LD_LIBRARY_PATH: ~a~%" libpath)
+(eval-when (:compile-toplevel :execute)
+    (defconstant +debug+ nil))
+
+(defmacro debug-format (&rest body)
+  (when +debug+
+    `(format t ,@body)))
+
+(defun import-foreign-libraries ()
+  (let ((libpath (uiop/os:getcwd)))
+    (debug-format "=> New LD_LIBRARY_PATH: ~a~%" libpath)
     (pushnew libpath
              cffi:*foreign-library-directories*
              :test #'equal)
     (cffi:define-foreign-library libreadline
       (t "libreadline.so"))
     (cffi:use-foreign-library libreadline))
+  (debug-format "Loaded libraries: ~a~%" (cffi:list-foreign-libraries)))
+
+
+(defun main()
+  (import-foreign-libraries)
   (lisp-chat-client:main))
 
 ;; close currently foreign libraries loaded

--- a/build.lisp
+++ b/build.lisp
@@ -1,7 +1,23 @@
-(pushnew (truename (sb-unix:posix-getcwd/)) ql:*local-project-directories* )
+(pushnew (truename (sb-unix:posix-getcwd/)) ql:*local-project-directories*)
 (ql:register-local-projects)
-(ql:quickload :lisp-chat)
+(ql:quickload '(:lisp-chat :cffi))
+
+(defun main()
+  (let ((libpath (sb-posix:getcwd)))
+    (format t "=> New LD_LIBRARY_PATH: ~a~%" libpath)
+    (pushnew libpath
+             cffi:*foreign-library-directories*
+             :test #'equal)
+    (cffi:define-foreign-library libreadline
+      (t "libreadline.so"))
+    (cffi:use-foreign-library libreadline))
+  (lisp-chat-client:main))
+
+;; close currently foreign libraries loaded
+(loop for library in (cffi:list-foreign-libraries :loaded-only t)
+      do (cffi:close-foreign-library library))
+
 (sb-ext:save-lisp-and-die "lisp-chat"
-                          :toplevel #'lisp-chat-client:main
+                          :toplevel #'main
                           :executable t
-                          :compression 9)
+                          :compression 1)


### PR DESCRIPTION
Now it's possible just using `make` to generate a binary if there is a
proper environment prepared. However I didn't solve yet how I
distribute the binaries with dynamic libraries, but I'm trying.
Related problems & Solutions:

+ [Portacle Shared Libraries][1]
+ [How can I make sure ASDF loads a dynamic foreign library every time my system is loaded?][2]
+ [Delivering Common Lisp][3]
+ [How to specify CFFI load path?][4]
+ [How to unload dynamic libraries before save-and-die?][5]
+ [Distributing shared libraries with the executable on Linux (C/C++)][6]

[1]: https://github.com/portacle/portacle/issues/4
[2]: https://stackoverflow.com/questions/39885605/how-can-i-make-sure-asdf-loads-a-dynamic-foreign-library-every-time-my-system-is
[3]: https://borodust.org/delivering-common-lisp#bundle
[4]: https://sourceforge.net/p/sbcl/mailman/message/32104251/
[5]: https://sourceforge.net/p/sbcl/mailman/message/20522546/
[6]: https://aimlesslygoingforward.com/blog/2014/01/19/bundling-shared-libraries-on-linux/
