### PR TITLE
fix(web): normalize input username prefix gap

### DIFF
--- a/src/static/chat.js
+++ b/src/static/chat.js
@@ -48,10 +48,9 @@ function updateUsernamePrefix() {
         form.insertBefore(prefix, input);
     }
     if (username && loggedIn) {
-        prefix.textContent = `[${username}]: `;
+        prefix.textContent = `[${username}]:`;
         prefix.style.color = getUserColor(username);
         prefix.style.fontWeight = "bold";
-        prefix.style.marginRight = "5px";
         input.placeholder = "";
     } else {
         prefix.textContent = "";


### PR DESCRIPTION
# Preview: before -> after

Note: right gap between xani prefix and input box. 

<img width="1918" height="900" alt="Screenshot from 2026-01-29 16-03-42" src="https://github.com/user-attachments/assets/cff4bff8-5c20-485b-b446-b2f9c0e96cc0" />
