### PR TITLE
fix: lisp-chat-parse-version

### DIFF
--- a/lisp-chat.asd
+++ b/lisp-chat.asd
@@ -13,7 +13,8 @@
 
 (defun lisp-chat-parse-version ()
   (let* ((version (uiop:getenv "APP_VERSION"))
-         (index (search "-" version)))
+         (index (or (search "-" version)
+                    (search "+" version))))
     (if version
         (subseq version 0 index)
         "0.4.0")))


### PR DESCRIPTION
v0.5.0+20260211 wrongly parsed to nil