### PR TITLE
fix: stop saving @server messages to disk

### DIFF
--- a/src/server/base.lisp
+++ b/src/server/base.lisp
@@ -153,8 +153,7 @@
 (defun user-messages (&key (date-format nil) (channel "#general"))
   "Return only user messages, discard all messsages from @server"
   (mapcar (lambda (m) (formatted-message m :date-format date-format))
-          (remove-if #'(lambda (m) (or (equal (message-from m) "@server")
-                                       (not (string-equal (message-channel m) channel))))
+          (remove-if-not #'(lambda (m) (string-equal (message-channel m) channel))
                      *messages-log*)))
 
 (defun message-universal-time (message)

--- a/src/server/net.lisp
+++ b/src/server/net.lisp
@@ -66,6 +66,11 @@
         (t
          (websocket-driver:send socket message))))))
 
+(defun message-should-not-be-saved-p (message-raw)
+  "Messages that should be saved in the disk"
+  (or (gethash (message-channel message-raw) *private-channels*)
+      (equal (message-from message-raw ) "@server")))
+
 (defun message-broadcast ()
   "This procedure is a general independent thread to run brodcasting
    all the clients when a message is ping on this server"
@@ -74,7 +79,7 @@
                                    (pop *messages-stack*))))
                (when message-raw
                  (let ((message (formatted-message message-raw)))
-                   (unless (gethash (message-channel message-raw) *private-channels*)
+                   (unless (message-should-not-be-saved-p message-raw)
                      (push message-raw *messages-log*)
                      (save-message-to-disk message-raw))
                    (let ((clients *clients*))


### PR DESCRIPTION
Closes #115

There is no meaning on that, since @server are mainly notifications or
temporal events that doesn't show in any form using /log.