### PR TITLE
fix: unproper tcp socket closing

### DIFF
--- a/src/server/base.lisp
+++ b/src/server/base.lisp
@@ -39,6 +39,17 @@
   (active-channel "#general")
   (session-id (princ-to-string (uuid:make-v4-uuid))))
 
+(defun system-interrupt ()
+  #+sbcl 'sb-sys:interactive-interrupt
+  #+ccl  'ccl:interrupt-signal-condition
+  #+clisp 'system::simple-interrupt-condition
+  #+ecl 'ext:interactive-interrupt
+  #+allegro 'excl:interrupt-signal)
+
+(defun interrupt-thread-portable (thread)
+  (bt:interrupt-thread thread
+                       (lambda () (error (system-interrupt)))))
+
 (defun client-socket-type (client)
   (typecase (client-socket client)
     (usocket:stream-usocket "TCP")

--- a/src/server/main.lisp
+++ b/src/server/main.lisp
@@ -30,20 +30,20 @@
            (join-thread broadcast-thread))
       (progn
         (debug-format t "~%Shutting down...~%")
-        (sleep 1)
         (when web-handler
           (debug-format t "Stopping web server...~%")
           (handler-case (stop web-handler)
             (condition (c) (debug-format t "Error stopping web server: ~a~%" c))))
         (when (and connection-thread (thread-alive-p connection-thread))
           (debug-format t "Stopping connection handler...~%")
-          (destroy-thread connection-thread))
+          (interrupt-thread-portable connection-thread)
+          (join-thread connection-thread))
+        ;; delete residual web clients...
+        (dolist (client *clients*)
+          (client-delete client))
         (when (and broadcast-thread (thread-alive-p broadcast-thread))
           (debug-format t "Stopping message broadcast...~%")
-          (destroy-thread broadcast-thread))
-        (let ((clients *clients*))
-          (loop for client in clients
-                do (client-close client)))))))
+          (destroy-thread broadcast-thread))))))
 
 (defun main (&key (host *host*) (port *port*) (should-quit t))
   "Well, this function run all the necessary shits."
@@ -52,7 +52,7 @@
         (error-code 0))
     (unwind-protect
          (handler-case
-             (progn (setq socket-server (socket-listen host port))
+             (progn (setq socket-server (socket-listen host port :reuse-address t))
                     (server-loop socket-server))
            (usocket:address-in-use-error ()
              (format *error-output*
@@ -65,11 +65,7 @@
                      "error: There is no way to use ~a as host to run the server.~%"
                      *host*)
              (setq error-code 2))
-           (#+sbcl sb-sys:interactive-interrupt
-            #+ccl  ccl:interrupt-signal-condition
-            #+clisp system::simple-interrupt-condition
-            #+ecl ext:interactive-interrupt
-            #+allegro excl:interrupt-signal ()
+           (#.(system-interrupt) ()
              (format t "~%Closing the lisp-chat server...~%")))
       (when socket-server
         (socket-close socket-server))

--- a/src/server/net.lisp
+++ b/src/server/net.lisp
@@ -87,9 +87,9 @@
                            when (string-equal (message-channel message-raw)
                                               (client-active-channel client))
                              do (handler-case (send-message client message)
-                                (error (e)
-                                  (debug-format t "Error broadcasting to ~a: ~a~%" (client-name client) e)
-                                  (client-delete client))))))))))
+                                  (error (e)
+                                    (debug-format t "Error broadcasting to ~a: ~a~%" (client-name client) e)
+                                    (client-delete client))))))))))
 #+sbcl
 (sb-alien:define-alien-type tcp-info
   (sb-alien:struct tcp-info

--- a/src/server/tcp.lisp
+++ b/src/server/tcp.lisp
@@ -19,21 +19,10 @@
   "This procedure is a wrapper for CLIENT-READER-ROUTINE
    treating all the possible errors based on HANDLER-CASE macro."
   (handler-case (client-reader-routine client)
-    (end-of-file () (client-delete client))
-    (#+sbcl sb-int:simple-stream-error
-     #-sbcl error
-     ()
-      (progn (debug-format t "~a@~a timed output"
-                           (client-name client)
-                           (client-address client))
-             (client-delete client)))
-    (#+sbcl sb-bsd-sockets:not-connected-error
-     #-sbcl error
-     ()
-      (progn (debug-format t "~a@~a not connected more."
-                           (client-name client)
-                           (client-address client))
-             (client-delete client)))))
+    (#.(system-interrupt) () (client-delete client))
+    (error (c)
+      (declare (ignore c))
+      (client-delete client))))
 
 (defun create-client (connection)
   "This procedure create a new client based on CONNECTION made by
@@ -60,8 +49,9 @@
       (user-joined-message client)
       (when history-channel
         (send-message client (command-message (format nil "You were restored to channel ~a" active-channel))))
-      (make-thread (lambda () (client-reader client))
-                   :name (format nil "~a reader thread" (client-name client))))))
+      (make-thread
+         (lambda () (client-reader client))
+         :name (format nil "reader-thread: ~a" (client-name client))))))
 
 ;; a function defined to handle the errors of client thread
 (defun safe-client-thread (connection)
@@ -71,9 +61,23 @@ exceptions."
     (end-of-file () nil)
     (usocket:address-in-use-error () nil)))
 
+(defun interrupt-client-reader-threads ()
+  (let ((prefix "reader-thread:"))
+  (dolist (thread (bt:all-threads))
+    (let ((name (bt:thread-name thread)))
+      (when (and name
+                 (> (length name) (length prefix))
+                 (string= prefix (subseq name 0 (length prefix))))
+        (when (bt:thread-alive-p thread)
+          (interrupt-thread-portable thread)
+          (join-thread thread)))))))
+
 (defun connection-handler (socket-server)
   "This is a special thread just for accepting connections from SOCKET-SERVER
    and creating new clients from it."
-  (loop for connection = (socket-accept socket-server)
-        do (make-thread (lambda () (safe-client-thread connection))
-                        :name "create client")))
+  (handler-case
+       (loop for connection = (socket-accept socket-server)
+         do (make-thread (lambda () (safe-client-thread connection))
+                         :name "create client"))
+    (#.(system-interrupt) ()
+      (interrupt-client-reader-threads))))

--- a/tests/main.lisp
+++ b/tests/main.lisp
@@ -24,8 +24,7 @@
 
 (defun stop-test-server ()
   (when (and *server-thread* (bt:thread-alive-p *server-thread*))
-    #-sbcl (bt:destroy-thread *server-thread*)
-    #+sbcl (bt:interrupt-thread *server-thread* (lambda () (error 'sb-sys:interactive-interrupt))))
+    (interrupt-thread-portable *server-thread*))
   (setf *server-thread* nil)
   (sleep 1))
 

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -1,5 +1,6 @@
 (defpackage :lisp-chat/tests
   (:use :cl :cl-user :parachute :lisp-chat/config)
+  (:import-from :lisp-chat/server :interrupt-thread-portable)
   (:import-from :usocket :socket-connect :socket-close :socket-stream)
   (:import-from :websocket-driver :start-connection :send :on :close-connection)
   (:import-from :websocket-driver-client :make-client)


### PR DESCRIPTION
Closes #44

- review tcp socket closing and interrupt tcp-client-read threads
- create a interrupt-thread-portable using system-interrupt reader macros
- for residual web clients in main, use client-delete instead client-close
- set :reuse-address to avoid problems in restart over tcp server socket