### PR TITLE
fix: uptime global var init in main function

### DIFF
--- a/src/server/base.lisp
+++ b/src/server/base.lisp
@@ -16,6 +16,8 @@
 (defvar *day-names* '("Monday" "Tuesday" "Wednesday"
                       "Thursday" "Friday" "Saturday" "Sunday")
   "Day names")
+(defvar *uptime* nil "Uptime of server variable, initialized at server start")
+
 
 (defstruct message
   "This structure abstract the type message with is saved

--- a/src/server/commands.lisp
+++ b/src/server/commands.lisp
@@ -13,8 +13,6 @@
                              cl:macroexpand
                              cl:macroexpand-1)))
 
-(defvar *uptime* (server:get-time) "Uptime of server variable")
-
 (defun get-commands ()
   "Returns a list of all available command strings."
   (let ((commands '()))
@@ -245,7 +243,7 @@
   "/uptime returns a human-readable string to preset the uptime since the server started."
   (declare (ignorable client args))
   (server:command-message
-   (format nil "Server online since ~a" (server:format-time *uptime*))))
+   (format nil "Server online since ~a" (server:format-time server:*uptime*))))
 
 (defun /session (client &rest args)
   "/session returns the unique session UUID for the current client."

--- a/src/server/main.lisp
+++ b/src/server/main.lisp
@@ -46,7 +46,8 @@
           (bt:destroy-thread broadcast-thread))))))
 
 (defun main (&key (host config:*host*) (port config:*port*) (should-quit t))
-  "Well, this function run all the necessary shits."
+  "Main entrypoint to start the tcp-server and http server (with websockets)"
+  (setq *uptime* (get-time))
   (load-persistent-messages)
   (let ((socket-server nil)
         (error-code 0))

--- a/src/server/package.lisp
+++ b/src/server/package.lisp
@@ -23,6 +23,7 @@
            #:*private-channels*
            #:*server-nickname*
            #:*raw-command-message*
+           #:*uptime*
            #:client-name
            #:client-address
            #:client-time


### PR DESCRIPTION
Closes #120

Instead of being initialized in compile-time, only init in the (main)
function, this ensure the proper uptime with correct runtime
TZ (timezone) settings.