### PR TITLE
fix: normalize channel names with or without hashtag

### DIFF
--- a/src/server/api.lisp
+++ b/src/server/api.lisp
@@ -60,7 +60,7 @@
              `(400 (:content-type "application/json") ("{\"error\": \"Invalid JSON in request body\"}"))
              (let* ((args (gethash "args" payload nil))
                     (kwargs-hash (gethash "kwargs" payload nil))
-                    (channel-override (gethash "channel" payload nil))
+                    (channel-override (normalize-channel (gethash "channel" payload nil)))
                     (active-client (if channel-override
                                        (let ((new-client (copy-client client)))
                                          (setf (client-active-channel new-client) channel-override)

--- a/src/server/base.lisp
+++ b/src/server/base.lisp
@@ -171,6 +171,18 @@
             for c2 across substring
             always (equal c1 c2)))))
 
+(defun normalize-channel (channel)
+  "Normalize channel name. Ensure it starts with #."
+  (when (and channel (> (length channel) 0))
+    (let ((c (string-trim '(#\Space #\Return #\Newline #\Tab) channel)))
+      (when (uiop:string-prefix-p "%23" c)
+        (setf c (subseq c 3)))
+      (when (uiop:string-prefix-p "#" c)
+        (setf c (subseq c 1)))
+      (if (zerop (length c))
+          nil
+          (concatenate 'string "#" c)))))
+
 (defun format-message-line (time from content)
   (format nil "|~a| [~a]: ~a" time from content))
 

--- a/src/server/commands.lisp
+++ b/src/server/commands.lisp
@@ -115,7 +115,7 @@
    If CHANNEL is provided, show users in that channel."
   (declare (ignorable args))
   (let* ((target-channel (if channel
-                             (if (uiop:string-prefix-p "#" channel) channel (concatenate 'string "#" channel))
+                             (server:normalize-channel channel)
                              (server:client-active-channel client)))
          (channel-users (remove-if-not (lambda (c) (string-equal (server:client-active-channel c)
                                                             target-channel))
@@ -126,7 +126,7 @@
   "/join changes the active channel for the user"
   (declare (ignorable args))
   (if channel
-      (let ((new-channel (if (uiop:string-prefix-p "#" channel) channel (concatenate 'string "#" channel)))
+      (let ((new-channel (server:normalize-channel channel))
             (old-channel (server:client-active-channel client)))
         (if (string-equal new-channel old-channel)
             (server:command-message (format nil "You are already in ~a" new-channel))

--- a/src/server/package.lisp
+++ b/src/server/package.lisp
@@ -57,7 +57,8 @@
            #:client-latency-ms
            #:reset-server
            #:split
-           #:startswith))
+           #:startswith
+           #:normalize-channel))
 
 (defpackage #:lisp-chat/commands
   (:use #:cl)

--- a/src/server/web.lisp
+++ b/src/server/web.lisp
@@ -24,8 +24,7 @@
   (let* ((params (uiop:split-string (or query-string "") :separator "&"))
          (channel-param (find-if (lambda (p) (uiop:string-prefix-p "channel=" p)) params)))
     (if channel-param
-        (let ((val (subseq channel-param 8)))
-          (if (uiop:string-prefix-p "#" val) val (concatenate 'string "#" val)))
+        (normalize-channel (subseq channel-param 8))
         nil)))
 
 (defun ws-app (env)

--- a/tests/unit.lisp
+++ b/tests/unit.lisp
@@ -45,3 +45,16 @@
    (is equal
        3
        (count #\@ message-string :test #'char-equal))))
+
+(define-test channel-normalization
+  :parent unit-tests
+  (is string= "#general" (server:normalize-channel "general"))
+  (is string= "#general" (server:normalize-channel "#general"))
+  (is string= "#general" (server:normalize-channel "%23general"))
+  (is string= "#general" (server:normalize-channel "  #general  "))
+  (is string= "#general" (server:normalize-channel "%23#general"))
+  (is eq nil (server:normalize-channel ""))
+  (is eq nil (server:normalize-channel "  "))
+  (is eq nil (server:normalize-channel "#"))
+  (is eq nil (server:normalize-channel "%23"))
+  (is eq nil (server:normalize-channel nil)))


### PR DESCRIPTION
Channels referenced with '#', '%23', or without a hashtag are now
consistently normalized to a single format starting with a '#'. This
resolves issues where query params or API payload formats could result
in duplicate or malformed channel names.

Closes #121