### PR TITLE
server: add :global parameter for /log, /search and /users

### DIFF
--- a/src/server/base.lisp
+++ b/src/server/base.lisp
@@ -186,12 +186,14 @@
 (defun format-message-line (time from content)
   (format nil "|~a| [~a]: ~a" time from content))
 
-(defun formatted-message (message &key (date-format nil))
+(defun formatted-message (message &key (date-format nil) (global nil))
   "The default message format of this server. MESSAGE is a struct message"
   (let* ((time-str (if (string= date-format "date")
                        (message-time-date-format message)
                        (message-time-hour-format message)))
-         (from-str (message-from message))
+         (from-str (if global
+                       (format nil "~a:~a" (message-channel message) (message-from message))
+                       (message-from message)))
          (content-str (message-content message))
          (lines (split content-str :empty-seqs t :delimiterp (lambda (c) (char= c #\Newline)))))
     (format nil "~{~a~^~%~}"
@@ -199,10 +201,10 @@
                       (format-message-line time-str from-str line))
                     lines))))
 
-(defun user-messages (&key (date-format nil) (channel "#general"))
+(defun user-messages (&key (date-format nil) (channel "#general") (global nil))
   "Return only user messages, discard all messsages from @server"
-  (mapcar (lambda (m) (formatted-message m :date-format date-format))
-          (remove-if-not #'(lambda (m) (string-equal (message-channel m) channel))
+  (mapcar (lambda (m) (formatted-message m :date-format date-format :global global))
+          (remove-if-not #'(lambda (m) (or global (string-equal (message-channel m) channel)))
                      *messages-log*)))
 
 (defun message-universal-time (message)
@@ -231,13 +233,16 @@
                                (nth 0 date-fields)))      ;; year
     (error () nil)))
 
-(defun search-message (message &key)
+(defun search-message (message &key (global nil))
   "Format a message for the /search command.
-   The user part is prefixed with search:username."
-  (format nil "|~a| [search:~a]: ~a"
-          (message-time-date-format message)
-          (message-from message)
-          (message-content message)))
+   The user part is prefixed with search:username or channel:username if global."
+  (let ((user-part (if global
+                       (format nil "~a:~a" (message-channel message) (message-from message))
+                       (format nil "search:~a" (message-from message)))))
+    (format nil "|~a| [~a]: ~a"
+            (message-time-date-format message)
+            user-part
+            (message-content message))))
 
 (defun command-message (content)
   "This function prepare the CONTENT as a message by the @server"

--- a/src/server/commands.lisp
+++ b/src/server/commands.lisp
@@ -62,6 +62,9 @@
       ((and (string-equal command "/log")
             (eq (length args) 1))
        (/log client :depth (car args) :date-format "date"))
+      ((and (string-equal command "/users")
+            (eq (length args) 1))
+       (/users client :channel (car args)))
       ((string-equal command "/dm") (/dm client (car args) (extract-args-as-string message :accessor #'cddr)))
       ((string-equal command "/lisp") (/lisp client (extract-args-as-string message)))
       (command-function (apply command-function (cons client (parse-keywords args))))
@@ -73,14 +76,15 @@
       (write-to-string s)))
 
 ;; user commands prefixed with /
-(defun /search (client query &rest args &key user (limit "10") before after &allow-other-keys)
+(defun /search (client query &rest args &key user (limit "10") before after (global nil) &allow-other-keys)
   "/search QUERY searches for messages containing QUERY as substring.
    QUERY is an mandatory parameter.
    KEY PARAMETERS:
    :user USERNAME   - Filter by a specific user.
    :limit NUMBER    - Maximum number of messages to return (default 10).
    :before ISO-DATE - ISO format datetime filter (e.g., 2026-02-22T14:30).
-   :after ISO-DATE  - ISO format datetime filter (e.g., 2026-02-22T14:30)."
+   :after ISO-DATE  - ISO format datetime filter (e.g., 2026-02-22T14:30).
+   :global BOOLEAN  - Search across all channels."
   (declare (ignorable client args))
   (if (not query)
       (server:command-message "error: QUERY is mandatory parameter. Try /search QUERY")
@@ -91,7 +95,8 @@
              (filtered (remove-if-not
                         (lambda (m)
                           (and (not (equal (server:message-from m) "@server"))
-                               (string-equal (server:message-channel m) (server:client-active-channel client))
+                               (or global
+                                   (string-equal (server:message-channel m) (server:client-active-channel client)))
                                (search query
                                        (server:message-content m)
                                        :test #'char-equal)
@@ -107,19 +112,21 @@
         (if (not limited)
             (server:command-message "the search returned a empty result")
             (format nil "~{~a~^~%~}"
-                    (mapcar (lambda (m) (server:search-message m))
+                    (mapcar (lambda (m) (server:search-message m :global global))
                             (reverse limited)))))))
 
-(defun /users (client &optional (channel nil) &rest args)
-  "/users returns a list separated by commas of the currently logged users in the current channel.
-   If CHANNEL is provided, show users in that channel."
-  (declare (ignorable args))
+(defun /users (client &key (channel nil) (global nil) &allow-other-keys)
+  "/users returns a list separated by commas of the currently logged users.
+   If CHANNEL is provided, show users in that channel.
+   If GLOBAL is provided, show users in all channels."
   (let* ((target-channel (if channel
                              (server:normalize-channel channel)
                              (server:client-active-channel client)))
-         (channel-users (remove-if-not (lambda (c) (string-equal (server:client-active-channel c)
-                                                            target-channel))
-                                       server:*clients*)))
+         (channel-users (if global
+                            server:*clients*
+                            (remove-if-not (lambda (c) (string-equal (server:client-active-channel c)
+                                                               target-channel))
+                                           server:*clients*))))
     (server:command-message (format nil "users: ~{~a~^, ~}" (mapcar #'server:client-name channel-users)))))
 
 (defun /join (client &optional (channel nil) &rest args)
@@ -230,11 +237,14 @@
          (note "Note: /clear and /quit are front-end commands, depending the implementation of the client."))
     (server:command-message (format nil "Manual of lisp-chat:~%~{~a~^~%~}~%~%~a" docs note))))
 
-(defun /log (client &key (depth "20") (date-format nil) &allow-other-keys)
+(defun /log (client &key (depth "20") (date-format nil) (global nil) &allow-other-keys)
   "/log shows the last messages sent to the server.
-   DEPTH is optional number of messages frames from log"
+   DEPTH is optional number of messages frames from log
+   GLOBAL is optional boolean to search across all channels"
   (declare (ignorable client))
-  (let* ((messages (server:user-messages :date-format date-format :channel (server:client-active-channel client)))
+  (let* ((messages (server:user-messages :date-format date-format
+                                         :channel (server:client-active-channel client)
+                                         :global global))
          (log-size (min (or (parse-integer depth :junk-allowed t) 20)
                         (length messages))))
     (format nil "~{~a~^~%~}" (reverse (subseq messages 0


### PR DESCRIPTION
- /log and /search now support :global t to search across all channels
- Presentation layer prefixes channel:user when global results are shown
- /users refactored to use &key parameters, supporting :global t
- Added backward compatibility for /users <channel>

Closes #110

# Preview

`/search bug :global t`

<img width="490" height="602" alt="image" src="https://github.com/user-attachments/assets/7dc5a044-0616-4c81-84af-0ab23d80599f" />
