### PR TITLE
feat: input history key up/down

### DIFF
--- a/src/static/main.js
+++ b/src/static/main.js
@@ -3,9 +3,12 @@ import auth from './modules/auth.js';
 import network from './modules/network.js';
 import autocomplete from './modules/autocomplete.js';
 import messages from './modules/messages.js';
+import inputHistory from './modules/input.js';
 
 const form = document.getElementById("input-area");
 const input = document.getElementById("message-input");
+
+inputHistory.initInputHistory(input);
 
 form.addEventListener("submit", (e) => {
     e.preventDefault();
@@ -13,6 +16,9 @@ form.addEventListener("submit", (e) => {
     const trimmed = value.trim();
     if (value && network.getWs() && network.getWs().readyState === WebSocket.OPEN) {
         autocomplete.closeAutocomplete();
+        if (trimmed) {
+            inputHistory.addMessageToHistory(value);
+        }
         if (trimmed === "/clear") {
             messages.clearMessages();
             input.value = "";

--- a/src/static/modules/input.js
+++ b/src/static/modules/input.js
@@ -1,0 +1,45 @@
+const messageHistory = [];
+let historyIndex = 0;
+let currentDraft = "";
+
+function initInputHistory(inputElement) {
+    inputElement.addEventListener("keydown", (e) => {
+        const autocompletePopup = document.getElementById("autocomplete-popup");
+        if (autocompletePopup && !autocompletePopup.classList.contains("hidden")) return;
+
+        if (e.key === "ArrowUp") {
+            if (messageHistory.length > 0) {
+                e.preventDefault();
+                if (historyIndex === messageHistory.length) {
+                    currentDraft = inputElement.value;
+                }
+                if (historyIndex > 0) {
+                    historyIndex--;
+                    inputElement.value = messageHistory[historyIndex];
+                }
+            }
+        } else if (e.key === "ArrowDown") {
+            if (messageHistory.length > 0) {
+                e.preventDefault();
+                if (historyIndex < messageHistory.length - 1) {
+                    historyIndex++;
+                    inputElement.value = messageHistory[historyIndex];
+                } else if (historyIndex === messageHistory.length - 1) {
+                    historyIndex++;
+                    inputElement.value = currentDraft;
+                }
+            }
+        }
+    });
+}
+
+function addMessageToHistory(message) {
+    messageHistory.push(message);
+    historyIndex = messageHistory.length;
+    currentDraft = "";
+}
+
+export default {
+    initInputHistory,
+    addMessageToHistory
+};


### PR DESCRIPTION
Similar to readline and shell history commands, user now can restore
the last message to the input buffer and edit before send
again. Useful by writing some commands or fast edits.

cc: proposed originally by @lubien