### PR TITLE
feat(web): implement reply feature with message hyperlinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ ROS_TEST_FLAGS = -e "(sb-ext:disable-debugger)" -s lisp-chat/tests
 lint:
 	mallet --format line src tests
 
+lint-fix:
+	mallet --fix src tests
+
+
 docker-lint:
 	docker run --rm -t -v $(PWD):/src fukamachi/mallet:latest --format line src tests
 

--- a/src/admin.lisp
+++ b/src/admin.lisp
@@ -77,7 +77,7 @@
     (when limit
       (setf messages (last messages limit)))
     (dolist (m messages)
-      (format t "~a~%" (server:formatted-message m :date-format "date")))))
+      (format t "~a~%" (server:formatted-message m :client nil :date-format "date")))))
 
 (defun stats (&key (days 7))
   (let ((messages (load-messages))

--- a/src/server/base.lisp
+++ b/src/server/base.lisp
@@ -37,7 +37,6 @@
   (multiple-value-list (get-decoded-time)))
 
 
-
 (defun reset-server ()
   "Reset the server state."
   (bt:with-lock-held (*client-lock*)

--- a/src/server/commands.lisp
+++ b/src/server/commands.lisp
@@ -60,7 +60,8 @@
   (when (server:startswith message "/")
     (handler-case (call-command-predefined client message)
       (error (c)
-        (server:command-message (format nil "command '~a' finished with error: ~a" message c))))))
+        (server:command-message (format nil "command '~a' finished with error: ~a" message c)
+                                :client client)))))
 
 (defun call-command-predefined (client message)
   (let* ((command-name (extract-command message))
@@ -78,7 +79,8 @@
       ((string-equal command "/dm") (/dm client (car args) (extract-args-as-string message :accessor #'cddr)))
       ((string-equal command "/lisp") (/lisp client (extract-args-as-string message)))
       (command-function (apply command-function (cons client (parse-keywords args))))
-      (t (server:command-message (format nil "command ~a doesn't exists" message))))))
+      (t (server:command-message (format nil "command ~a doesn't exists" message)
+                                 :client client)))))
 
 (defun ensure-string (s)
   (if (stringp s)
@@ -114,7 +116,7 @@
    :global BOOLEAN  - Search across all channels."
   (declare (ignorable client args))
   (if (not query)
-      (server:command-message "error: QUERY is mandatory parameter. Try /search QUERY")
+      (server:command-message "error: QUERY is mandatory parameter. Try /search QUERY" :client client)
       (let* ((parsed-limit (parse-integer (ensure-string limit) :junk-allowed t))
              (before-time (server:parse-iso8601 (ensure-string before)))
              (after-time (server:parse-iso8601 (ensure-string after)))
@@ -122,9 +124,9 @@
                                         :before-time before-time :after-time after-time))
              (limited (subseq filtered 0 (min (length filtered) parsed-limit))))
         (if (not limited)
-            (server:command-message "the search returned a empty result")
+            (server:command-message "the search returned a empty result" :client client)
             (format nil "~{~a~^~%~}"
-                    (mapcar (lambda (m) (server:search-message m :global global))
+                    (mapcar (lambda (m) (server:search-message m :client client :global global))
                             (reverse limited)))))))
 
 (define-command /users (client &key (channel nil) (global nil) &allow-other-keys)
@@ -139,7 +141,8 @@
                             (remove-if-not (lambda (c) (string-equal (server:client-active-channel c)
                                                                target-channel))
                                            server:*clients*))))
-    (server:command-message (format nil "users: ~{~a~^, ~}" (mapcar #'server:client-name channel-users)))))
+    (server:command-message (format nil "users: ~{~a~^, ~}" (mapcar #'server:client-name channel-users))
+                            :client client)))
 
 (define-command /join (client &optional (channel nil))
   "/join changes the active channel for the user"
@@ -147,13 +150,13 @@
       (let ((new-channel (server:normalize-channel channel))
             (old-channel (server:client-active-channel client)))
         (if (string-equal new-channel old-channel)
-            (server:command-message (format nil "You are already in ~a" new-channel))
+            (server:command-message (format nil "You are already in ~a" new-channel) :client client)
             (prog1 'ignore
               (server:user-exited-message client)
               (setf (server:client-active-channel client) new-channel)
               (setf (gethash (server:client-name client) server:*user-channels*) new-channel)
               (server:user-joined-message client))))
-      (server:command-message "/join #CHANNEL-NAME")))
+      (server:command-message "/join #CHANNEL-NAME" :client client)))
 
 (define-command /channels (client &rest args &key (usernames nil) (all nil) &allow-other-keys)
   "/channels lists active channels and their user counts.
@@ -178,7 +181,8 @@
                              lines)
                        (push (format nil "~a: ~a user~:p" chan (length users)) lines))))
                chan-users)
-      (server:command-message (format nil "channels:~%~{~a~^~%~}" (sort lines #'string<))))))
+      (server:command-message (format nil "channels:~%~{~a~^~%~}" (sort lines #'string<))
+                              :client client))))
 
 (define-command /private (client &optional (action nil) &rest args)
   "/private toggles or sets the private mode for the current channel.
@@ -187,18 +191,21 @@
   (declare (ignorable args))
   (let ((channel (server:client-active-channel client)))
     (if (string-equal channel "#general")
-        (server:command-message "This mode cannot be activated in the #general channel.")
+        (server:command-message "This mode cannot be activated in the #general channel." :client client)
         (let ((is-private (gethash channel server:*private-channels*)))
           (cond
             ((string-equal action "status")
-             (server:command-message (format nil "Private mode for ~a is currently ~:[OFF~;ON~]." channel is-private)))
+             (server:command-message (format nil "Private mode for ~a is currently ~:[OFF~;ON~]."
+                                             channel is-private)
+                                     :client client))
             ((or (null action) (string-equal action "on") (string-equal action "off"))
              (let ((turn-on (cond
                               ((string-equal action "on") t)
                               ((string-equal action "off") nil)
                               (t (not is-private)))))
                (if (eq (not (null is-private)) turn-on)
-                   (server:command-message (format nil "Private mode is already ~:[OFF~;ON~]." turn-on))
+                   (server:command-message (format nil "Private mode is already ~:[OFF~;ON~]." turn-on)
+                                           :client client)
                    (prog1 'ignore
                      (setf (gethash channel server:*private-channels*) turn-on)
                      (server:push-message "@server"
@@ -206,7 +213,7 @@
                                            turn-on (server:client-name client))
                                    :channel channel)))))
             (t
-             (server:command-message "Usage: /private [on|off|status]")))))))
+             (server:command-message "Usage: /private [on|off|status]" :client client)))))))
 
 (define-command /ping (client &rest args)
   "/ping responds with a 'pong' message, echoing the provided arguments or the user's nickname."
@@ -215,7 +222,8 @@
          (latency-msg (if latency
                           (format nil " | latency: ~,2fms" latency)
                           "")))
-    (server:command-message (format nil "pong ~a~a" (or args (server:client-name client)) latency-msg))))
+    (server:command-message (format nil "pong ~a~a" (or args (server:client-name client)) latency-msg)
+                            :client client)))
 
 
 (define-command /help (client &optional command-name &rest args)
@@ -229,9 +237,10 @@
              (sym (get-command cmd)))
         (if (and sym (fboundp sym))
             (server:command-message (or (documentation sym 'function)
-                                 (format nil "No documentation for ~a" cmd)))
-            (server:command-message (format nil "Command ~a not found." cmd))))
-      (server:command-message (format nil "Available commands: ~{~a~^, ~}" (get-commands)))))
+                                 (format nil "No documentation for ~a" cmd))
+                                    :client client)
+            (server:command-message (format nil "Command ~a not found." cmd) :client client)))
+      (server:command-message (format nil "Available commands: ~{~a~^, ~}" (get-commands)) :client client)))
 
 (define-command /man (client &rest args)
   "/man shows the docstrings of all available commands"
@@ -246,7 +255,7 @@
                                (format nil "~a: No documentation" cmd))))
                        commands))
          (note "Note: /clear and /quit are front-end commands, depending the implementation of the client."))
-    (server:command-message (format nil "Manual of lisp-chat:~%~{~a~^~%~}~%~%~a" docs note))))
+    (server:command-message (format nil "Manual of lisp-chat:~%~{~a~^~%~}~%~%~a" docs note) :client client)))
 
 (defun get-messages-around (messages around-time limit)
   (let* ((sorted (sort (copy-list messages)
@@ -275,7 +284,10 @@
          (processed (if around-time
                         (get-messages-around filtered around-time parsed-depth)
                         (subseq filtered 0 (min parsed-depth (length filtered)))))
-         (formatted (mapcar (lambda (m) (server:formatted-message m :date-format date-format :global global :timezone (server:client-timezone client) :expand-reply (server:client-expand-reply client)))
+         (formatted (mapcar (lambda (m)
+                              (server:formatted-message m :client client
+                                                        :date-format date-format
+                                                        :global global))
                             processed)))
     (format nil "~{~a~^~%~}" (reverse formatted))))
 
@@ -283,12 +295,14 @@
   "/uptime returns a human-readable string to preset the uptime since the server started."
   (declare (ignorable client args))
   (server:command-message
-   (format nil "Server online since ~a" (server:format-time server:*uptime*))))
+   (format nil "Server online since ~a" (server:format-time server:*uptime*))
+   :client client))
 
 (define-command /session (client &rest args)
   "/session returns the unique session UUID for the current client."
   (declare (ignorable args))
-  (server:command-message (format nil "Your session ID is: ~A" (server:client-session-id client))))
+  (server:command-message (format nil "Your session ID is: ~A" (server:client-session-id client))
+                          :client client))
 
 (define-command /nick (client &optional (new-nick nil) &rest args)
   "/nick changes the server:client-name given a NEW-NICK which should be a string"
@@ -301,29 +315,32 @@
                               new-nick)
                       :channel (server:client-active-channel client))
         (setf (server:client-name client) new-nick)
-        (server:command-message (format nil "Your new nick is: @~a" new-nick) (server:client-timezone client) (server:client-expand-reply client)))
-      (server:command-message (format nil "/nick NEW-NICKNAME") (server:client-timezone client) (server:client-expand-reply client))))
+        (server:command-message (format nil "Your new nick is: @~a" new-nick) :client client))
+      (server:command-message (format nil "/nick NEW-NICKNAME") :client client)))
 
 (define-command /dm (client &optional (username nil) msg-content)
   "/dm sends a direct message to a USERNAME"
   (let ((from (server:client-name client))
         (user (server:get-client username)))
     (cond
-      ((not username) (server:command-message "/dm USERNAME your message" (server:client-timezone client) (server:client-expand-reply client)))
-      ((not user) (server:command-message (format nil "error: ~s user not found" username) (server:client-timezone client) (server:client-expand-reply client)))
-      ((string= from username) (server:command-message "you can't dm to yourself" (server:client-timezone client) (server:client-expand-reply client)))
+      ((not username)
+       (server:command-message "/dm USERNAME your message" :client client))
+      ((not user)
+       (server:command-message (format nil "error: ~s user not found" username) :client client))
+      ((string= from username)
+       (server:command-message "you can't dm to yourself" :client client))
       (t
        (prog1 'ignore
-          (server:send-message client (server:private-message from msg-content (server:client-timezone client) (server:client-expand-reply client)))
-         (server:send-message user (server:private-message from msg-content (server:client-timezone user) (server:client-expand-reply user))))))))
+         (server:send-message client (server:private-message from msg-content :client client))
+         (server:send-message user (server:private-message from msg-content :client user)))))))
 
 (define-command /whois (client &optional (username nil))
   "/whois get basic information of a online USERNAME"
   (declare (ignorable client))
   (let ((user (server:get-client username)))
     (cond
-      ((not username) (server:command-message "/whois USERNAME" (server:client-timezone client)))
-      ((not user) (server:command-message (format nil "error: ~s user not found" username) (server:client-timezone client)))
+      ((not username) (server:command-message "/whois USERNAME" :client client))
+      ((not user) (server:command-message (format nil "error: ~s user not found" username) :client client))
       (t
        (let ((formatted-time (server:format-time (server:client-time user)))
              (latency (server:client-latency-ms user))
@@ -341,13 +358,16 @@
                   formatted-time
                   (if user-agent
                       (format nil " | user-agent: ~a" user-agent)
-                      ""))))))))
+                      ""))
+          :client client))))))
+
 (define-command /version (client &rest args)
   "/version returns the current version of lisp-chat"
   (declare (ignorable client args))
   (server:command-message (format nil "lisp-chat v~a | src: ~a"
-                           (lisp-chat/config:get-version)
-                           lisp-chat/config:*source-code*)))
+                                  (lisp-chat/config:get-version)
+                                  lisp-chat/config:*source-code*)
+                          :client client))
 
 (define-command /whoami (client &rest args)
   "/whoami returns information about the current client session"

--- a/src/server/commands.lisp
+++ b/src/server/commands.lisp
@@ -275,7 +275,7 @@
          (processed (if around-time
                         (get-messages-around filtered around-time parsed-depth)
                         (subseq filtered 0 (min parsed-depth (length filtered)))))
-         (formatted (mapcar (lambda (m) (server:formatted-message m :date-format date-format :global global :timezone (server:client-timezone client)))
+         (formatted (mapcar (lambda (m) (server:formatted-message m :date-format date-format :global global :timezone (server:client-timezone client) :expand-reply (server:client-expand-reply client)))
                             processed)))
     (format nil "~{~a~^~%~}" (reverse formatted))))
 
@@ -301,21 +301,21 @@
                               new-nick)
                       :channel (server:client-active-channel client))
         (setf (server:client-name client) new-nick)
-        (server:command-message (format nil "Your new nick is: @~a" new-nick) (server:client-timezone client)))
-      (server:command-message (format nil "/nick NEW-NICKNAME") (server:client-timezone client))))
+        (server:command-message (format nil "Your new nick is: @~a" new-nick) (server:client-timezone client) (server:client-expand-reply client)))
+      (server:command-message (format nil "/nick NEW-NICKNAME") (server:client-timezone client) (server:client-expand-reply client))))
 
 (define-command /dm (client &optional (username nil) msg-content)
   "/dm sends a direct message to a USERNAME"
-  (let ((user (server:get-client username))
-        (from (server:client-name client)))
+  (let ((from (server:client-name client))
+        (user (server:get-client username)))
     (cond
-      ((not username) (server:command-message "/dm USERNAME your message" (server:client-timezone client)))
-      ((not user) (server:command-message (format nil "error: ~s user not found" username) (server:client-timezone client)))
-      ((string= from username) (server:command-message "you can't dm to yourself" (server:client-timezone client)))
+      ((not username) (server:command-message "/dm USERNAME your message" (server:client-timezone client) (server:client-expand-reply client)))
+      ((not user) (server:command-message (format nil "error: ~s user not found" username) (server:client-timezone client) (server:client-expand-reply client)))
+      ((string= from username) (server:command-message "you can't dm to yourself" (server:client-timezone client) (server:client-expand-reply client)))
       (t
        (prog1 'ignore
-         (server:send-message client (server:private-message from msg-content (server:client-timezone client)))
-         (server:send-message user (server:private-message from msg-content (server:client-timezone user))))))))
+          (server:send-message client (server:private-message from msg-content (server:client-timezone client) (server:client-expand-reply client)))
+         (server:send-message user (server:private-message from msg-content (server:client-timezone user) (server:client-expand-reply user))))))))
 
 (define-command /whois (client &optional (username nil))
   "/whois get basic information of a online USERNAME"

--- a/src/server/formatter.lisp
+++ b/src/server/formatter.lisp
@@ -68,7 +68,14 @@
 (defun format-message-line (time from content)
   (format nil "|~a| [~a]: ~a" time from content))
 
-(defun formatted-message (message &key (date-format nil) (global nil) (timezone nil))
+(defun get-message-by-reference (channel date timeHM timeS user)
+  (find-if (lambda (m)
+             (and (string-equal (message-channel m) channel)
+                  (string-equal (message-from m) user)
+                  (string-equal (message-time-date-format m) (format nil "~a ~a:~a" date timeHM timeS))))
+           *messages-log*))
+
+(defun formatted-message (message &key (date-format nil) (global nil) (timezone nil) (expand-reply t))
   "The default message format of this server. MESSAGE is a struct message"
   (let* ((time-str (if (string= date-format "date")
                        (message-time-date-format message timezone)
@@ -76,16 +83,40 @@
          (from-str (if global
                        (format nil "~a:~a" (message-channel message) (message-from message))
                        (message-from message)))
-         (content-str (message-content message))
-         (lines (split content-str :empty-seqs t :delimiterp (lambda (c) (char= c #\Newline)))))
-    (format nil "~{~a~^~%~}"
-            (mapcar (lambda (line)
-                      (format-message-line time-str from-str line))
-                    lines))))
+         (raw-content (message-content message))
+         (content-str raw-content))
 
-(defun user-messages (&key (date-format nil) (channel "#general") (global nil) (timezone nil))
+    (when expand-reply
+      (cl-ppcre:do-scans (start end reg-starts reg-ends 
+                          "<(#?[A-zÀ-ú0-9_\\-]+):\\s*(\\d{4}-\\d{2}-\\d{2})\\s*(\\d{2}:\\d{2}):(\\d{2})\\s*\\[(.*?)\\]>"
+                          raw-content)
+        (let* ((channel (subseq raw-content (aref reg-starts 0) (aref reg-ends 0)))
+               (date (subseq raw-content (aref reg-starts 1) (aref reg-ends 1)))
+               (timeHM (subseq raw-content (aref reg-starts 2) (aref reg-ends 2)))
+               (timeS (subseq raw-content (aref reg-starts 3) (aref reg-ends 3)))
+               (user (subseq raw-content (aref reg-starts 4) (aref reg-ends 4)))
+               (ref-msg (get-message-by-reference channel date timeHM timeS user)))
+          (when ref-msg
+            (let* ((original-content (message-content ref-msg))
+                   (lines (split original-content :empty-seqs t :delimiterp (lambda (c) (char= c #\Newline))))
+                   (quoted-lines (format nil "~{~a~^~%~}"
+                                         (loop for line in lines
+                                               for i from 0
+                                               collect (if (= i 0)
+                                                           (format nil "> @~a: ~a" user line)
+                                                           (format nil "> ~a" line)))))
+                   (replacement (format nil "~a~%~a" quoted-lines (subseq raw-content end))))
+              (setf content-str (concatenate 'string (subseq raw-content 0 start) replacement)))))))
+              
+    (let ((lines (split content-str :empty-seqs t :delimiterp (lambda (c) (char= c #\Newline)))))
+      (format nil "~{~a~^~%~}"
+              (mapcar (lambda (line)
+                        (format-message-line time-str from-str line))
+                      lines)))))
+
+(defun user-messages (&key (date-format nil) (channel "#general") (global nil) (timezone nil) (expand-reply t))
   "Return only user messages, discard all messsages from @server"
-  (mapcar (lambda (m) (formatted-message m :date-format date-format :global global :timezone timezone))
+  (mapcar (lambda (m) (formatted-message m :date-format date-format :global global :timezone timezone :expand-reply expand-reply))
           (remove-if-not #'(lambda (m) (or global (string-equal (message-channel m) channel)))
                      *messages-log*)))
 
@@ -126,20 +157,20 @@
             user-part
             (message-content message))))
 
-(defun command-message (content &optional timezone)
+(defun command-message (content &optional timezone expand-reply)
   "This function prepare the CONTENT as a message by the @server"
   (if *raw-command-message*
       content
       (let* ((from *server-nickname*)
              (time (get-time))
              (message (make-message :from from :content content :time time)))
-        (formatted-message message :timezone timezone))))
+        (formatted-message message :timezone timezone :expand-reply expand-reply))))
 
-(defun private-message (client-name content &optional timezone)
+(defun private-message (client-name content &optional timezone expand-reply)
   "This function prepare the CONTENT as a message by the @server"
   (let* ((from (format nil "dm:~a" client-name))
          (time (get-time))
          (message (make-message :from from
                                 :content content
                                 :time time)))
-    (formatted-message message :timezone timezone)))
+    (formatted-message message :timezone timezone :expand-reply expand-reply)))

--- a/src/server/formatter.lisp
+++ b/src/server/formatter.lisp
@@ -107,7 +107,7 @@
                                                            (format nil "> ~a" line)))))
                    (replacement (format nil "~a~%~a" quoted-lines (subseq raw-content end))))
               (setf content-str (concatenate 'string (subseq raw-content 0 start) replacement)))))))
-              
+
     (let ((lines (split content-str :empty-seqs t :delimiterp (lambda (c) (char= c #\Newline)))))
       (format nil "~{~a~^~%~}"
               (mapcar (lambda (line)

--- a/src/server/formatter.lisp
+++ b/src/server/formatter.lisp
@@ -68,57 +68,67 @@
 (defun format-message-line (time from content)
   (format nil "|~a| [~a]: ~a" time from content))
 
-(defun get-message-by-reference (channel date timeHM timeS user)
+(defun get-message-by-reference (channel date time user)
   (find-if (lambda (m)
              (and (string-equal (message-channel m) channel)
                   (string-equal (message-from m) user)
-                  (string-equal (message-time-date-format m) (format nil "~a ~a:~a" date timeHM timeS))))
+                  (string-equal (message-time-date-format m) (format nil "~a ~a" date time))))
            *messages-log*))
 
-(defun formatted-message (message &key (date-format nil) (global nil) (timezone nil) (expand-reply t))
+(defun expand-message-reply (raw-content)
+  "Expand message references in the content."
+  (let ((content-str raw-content))
+    (cl-ppcre:do-scans (start end reg-starts reg-ends
+                        "<(#?[A-zÀ-ú0-9_\\-]+):\\s*(\\d{4}-\\d{2}-\\d{2})\\s*(\\d{2}:\\d{2}:\\d{2})\\s*\\[(.*?)\\]>"
+                        raw-content)
+      (let* ((channel (subseq raw-content (aref reg-starts 0) (aref reg-ends 0)))
+             (date (subseq raw-content (aref reg-starts 1) (aref reg-ends 1)))
+             (time (subseq raw-content (aref reg-starts 2) (aref reg-ends 2)))
+             (user (subseq raw-content (aref reg-starts 3) (aref reg-ends 3)))
+             (ref-msg (get-message-by-reference channel date time user)))
+        (when ref-msg
+          (let* ((original-content (message-content ref-msg))
+                 (lines (split original-content :empty-seqs t :delimiterp (lambda (c) (char= c #\Newline))))
+                 (quoted-lines (format nil "~{~a~^~%~}"
+                                       (loop for line in lines
+                                             for i from 0
+                                             collect (if (= i 0)
+                                                         (format nil "> @~a: ~a" user line)
+                                                         (format nil "> ~a" line)))))
+                 (replacement (format nil "~a~%~a" quoted-lines (subseq raw-content end))))
+            (setf content-str (concatenate 'string (subseq raw-content 0 start) replacement))))))
+    content-str))
+
+(defun formatted-message (message &key (client nil) (date-format nil) (global nil))
   "The default message format of this server. MESSAGE is a struct message"
-  (let* ((time-str (if (string= date-format "date")
+  (let* ((timezone (when client (client-timezone client)))
+         (expand-reply (if client (client-expand-reply client) t))
+         (time-str (if (string= date-format "date")
                        (message-time-date-format message timezone)
                        (message-time-hour-format message timezone)))
          (from-str (if global
                        (format nil "~a:~a" (message-channel message) (message-from message))
                        (message-from message)))
-         (raw-content (message-content message))
-         (content-str raw-content))
+         (content-str (if expand-reply
+                          (expand-message-reply (message-content message))
+                          (message-content message)))
+         (lines (split content-str :empty-seqs t :delimiterp (lambda (c) (char= c #\Newline)))))
+    (format nil "~{~a~^~%~}"
+            (mapcar (lambda (line)
+                      (format-message-line time-str from-str line))
+                    lines))))
 
-    (when expand-reply
-      (cl-ppcre:do-scans (start end reg-starts reg-ends 
-                          "<(#?[A-zÀ-ú0-9_\\-]+):\\s*(\\d{4}-\\d{2}-\\d{2})\\s*(\\d{2}:\\d{2}):(\\d{2})\\s*\\[(.*?)\\]>"
-                          raw-content)
-        (let* ((channel (subseq raw-content (aref reg-starts 0) (aref reg-ends 0)))
-               (date (subseq raw-content (aref reg-starts 1) (aref reg-ends 1)))
-               (timeHM (subseq raw-content (aref reg-starts 2) (aref reg-ends 2)))
-               (timeS (subseq raw-content (aref reg-starts 3) (aref reg-ends 3)))
-               (user (subseq raw-content (aref reg-starts 4) (aref reg-ends 4)))
-               (ref-msg (get-message-by-reference channel date timeHM timeS user)))
-          (when ref-msg
-            (let* ((original-content (message-content ref-msg))
-                   (lines (split original-content :empty-seqs t :delimiterp (lambda (c) (char= c #\Newline))))
-                   (quoted-lines (format nil "~{~a~^~%~}"
-                                         (loop for line in lines
-                                               for i from 0
-                                               collect (if (= i 0)
-                                                           (format nil "> @~a: ~a" user line)
-                                                           (format nil "> ~a" line)))))
-                   (replacement (format nil "~a~%~a" quoted-lines (subseq raw-content end))))
-              (setf content-str (concatenate 'string (subseq raw-content 0 start) replacement)))))))
-
-    (let ((lines (split content-str :empty-seqs t :delimiterp (lambda (c) (char= c #\Newline)))))
-      (format nil "~{~a~^~%~}"
-              (mapcar (lambda (line)
-                        (format-message-line time-str from-str line))
-                      lines)))))
-
-(defun user-messages (&key (date-format nil) (channel "#general") (global nil) (timezone nil) (expand-reply t))
-  "Return only user messages, discard all messsages from @server"
-  (mapcar (lambda (m) (formatted-message m :date-format date-format :global global :timezone timezone :expand-reply expand-reply))
-          (remove-if-not #'(lambda (m) (or global (string-equal (message-channel m) channel)))
-                     *messages-log*)))
+(defun user-messages (&key (client nil) (date-format nil) (channel "#general") (global nil))
+  "Return only user messages, discard all messages from @server"
+  (let* ((messages (remove-if (lambda (m)
+                                (string-equal (message-from m) *server-nickname*))
+                              *messages-log*))
+         (filtered (remove-if-not (lambda (m)
+                                    (or global (string-equal (message-channel m) channel)))
+                                  messages)))
+    (mapcar (lambda (m)
+              (formatted-message m :client client :date-format date-format :global global))
+            filtered)))
 
 (defun message-universal-time (message)
   "Return the universal time of a message."
@@ -146,31 +156,32 @@
                                (nth 0 date-fields)))      ;; year
     (error () nil)))
 
-(defun search-message (message &key (global nil))
+(defun search-message (message &key (client nil) (global nil))
   "Format a message for the /search command.
    The user part is prefixed with search:username or channel:username if global."
   (let ((user-part (if global
                        (format nil "~a:~a" (message-channel message) (message-from message))
-                       (format nil "search:~a" (message-from message)))))
+                       (format nil "search:~a" (message-from message))))
+        (timezone (when client (client-timezone client))))
     (format nil "|~a| [~a]: ~a"
-            (message-time-date-format message)
+            (message-time-date-format message timezone)
             user-part
             (message-content message))))
 
-(defun command-message (content &optional timezone expand-reply)
+(defun command-message (content &key (client nil))
   "This function prepare the CONTENT as a message by the @server"
   (if *raw-command-message*
       content
       (let* ((from *server-nickname*)
              (time (get-time))
              (message (make-message :from from :content content :time time)))
-        (formatted-message message :timezone timezone :expand-reply expand-reply))))
+        (formatted-message message :client client))))
 
-(defun private-message (client-name content &optional timezone expand-reply)
+(defun private-message (client-name content &key (client nil))
   "This function prepare the CONTENT as a message by the @server"
   (let* ((from (format nil "dm:~a" client-name))
          (time (get-time))
          (message (make-message :from from
                                 :content content
                                 :time time)))
-    (formatted-message message :timezone timezone :expand-reply expand-reply)))
+    (formatted-message message :client client)))

--- a/src/server/models.lisp
+++ b/src/server/models.lisp
@@ -23,6 +23,7 @@
   (user-agent nil)
   (active-channel "#general")
   (timezone nil)
+  (expand-reply t)
   (session-id (princ-to-string (uuid:make-v4-uuid))))
 
 (defun client-socket-type (client)

--- a/src/server/net.lisp
+++ b/src/server/net.lisp
@@ -90,9 +90,7 @@
                          when (string-equal (message-channel message-raw)
                                             (client-active-channel client))
                            do (handler-case
-                                  (let ((message (formatted-message message-raw
-                                                                    :timezone (client-timezone client)
-                                                                    :expand-reply (client-expand-reply client))))
+                                  (let ((message (formatted-message message-raw :client client)))
                                     (send-message client message))
                                 (error (e)
                                   (debug-format t "Error broadcasting to ~a: ~a~%" (client-name client) e)

--- a/src/server/net.lisp
+++ b/src/server/net.lisp
@@ -90,7 +90,7 @@
                          when (string-equal (message-channel message-raw)
                                             (client-active-channel client))
                            do (handler-case
-                                  (let ((message (formatted-message message-raw 
+                                  (let ((message (formatted-message message-raw
                                                                     :timezone (client-timezone client)
                                                                     :expand-reply (client-expand-reply client))))
                                     (send-message client message))

--- a/src/server/net.lisp
+++ b/src/server/net.lisp
@@ -85,12 +85,14 @@
                    (bt:with-lock-held (*persistence-lock*)
                      (setf *persistence-queue* (append *persistence-queue* (list message-raw))))
                    (bt:signal-semaphore *persistence-semaphore*))
-                 (let ((clients *clients*))
+                  (let ((clients *clients*))
                    (loop for client in clients
                          when (string-equal (message-channel message-raw)
                                             (client-active-channel client))
                            do (handler-case
-                                  (let ((message (formatted-message message-raw :timezone (client-timezone client))))
+                                  (let ((message (formatted-message message-raw 
+                                                                    :timezone (client-timezone client)
+                                                                    :expand-reply (client-expand-reply client))))
                                     (send-message client message))
                                 (error (e)
                                   (debug-format t "Error broadcasting to ~a: ~a~%" (client-name client) e)

--- a/src/server/package.lisp
+++ b/src/server/package.lisp
@@ -32,6 +32,7 @@
            #:client-active-channel
            #:client-session-id
            #:client-timezone
+           #:client-expand-reply
            #:message
            #:message-from
            #:message-time

--- a/src/server/tcp.lisp
+++ b/src/server/tcp.lisp
@@ -48,7 +48,7 @@
         (push client *clients*))
       (user-joined-message client)
       (when history-channel
-        (send-message client (command-message (format nil "You were restored to channel ~a" active-channel))))
+        (send-message client (command-message (format nil "You were restored to channel ~a" active-channel) :client client)))
       (bt:make-thread
          (lambda () (client-reader client))
          :name (format nil "reader-thread: ~a" (client-name client))))))

--- a/src/server/web.lisp
+++ b/src/server/web.lisp
@@ -35,12 +35,21 @@
           (error () nil))
         nil)))
 
+(defun parse-expand-reply (query-string)
+  (let* ((params (uiop:split-string (or query-string "") :separator "&"))
+         (expand-param (find-if (lambda (p) (uiop:string-prefix-p "expand_reply=" p)) params)))
+    (if expand-param
+        (let ((val (subseq expand-param 13)))
+          (not (string-equal val "false")))
+        t)))
+
 (defun ws-app (env)
   (let* ((ws (make-server env))
          (client nil)
          (query-string (getf env :query-string))
          (channel (parse-channel query-string))
-         (tz (parse-tz query-string)))
+         (tz (parse-tz query-string))
+         (expand-reply (parse-expand-reply query-string)))
     (on :message ws
         (lambda (message)
           ;; (debug-format t "Received WS message: ~s~%" message)
@@ -56,7 +65,8 @@
                                                 :time (get-time)
                                                 :user-agent (gethash "user-agent" (getf env :headers))
                                                 :active-channel active-channel
-                                                :timezone tz))
+                                                :timezone tz
+                                                :expand-reply expand-reply))
                       (setf (gethash name *user-channels*) active-channel)
                       (bt:with-lock-held (*client-lock*)
                         (push client *clients*))

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -3,7 +3,7 @@ import auth from './modules/auth.js';
 import network from './modules/network.js';
 import autocomplete from './modules/autocomplete.js';
 import messages from './modules/messages.js';
-import inputHistory from './modules/input.js';
+import inputModule from './modules/input.js';
 import notifications from './modules/notifications.js';
 import history from './modules/history.js';
 import reply from "./modules/reply.js";
@@ -11,7 +11,8 @@ import reply from "./modules/reply.js";
 const form = document.getElementById("input-area");
 const input = document.getElementById("message-input");
 
-inputHistory.initInputHistory(input);
+inputModule.initInputHistory(input);
+inputModule.setupInputOverlay(input);
 reply.setupReplyFocus();
 
 form.addEventListener("submit", (e) => {
@@ -21,7 +22,7 @@ form.addEventListener("submit", (e) => {
     if (value && network.getWs() && network.getWs().readyState === WebSocket.OPEN) {
         autocomplete.closeAutocomplete();
         if (trimmed) {
-            inputHistory.addMessageToHistory(value);
+            inputModule.addMessageToHistory(value);
         }
         if (trimmed === "/clear") {
             messages.clearMessages();

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -6,13 +6,13 @@ import messages from './modules/messages.js';
 import inputHistory from './modules/input.js';
 import notifications from './modules/notifications.js';
 import history from './modules/history.js';
-import referenceFocus from './modules/referenceFocus.js';
+import { setupReplyFocus } from "./modules/reply.js";
 
 const form = document.getElementById("input-area");
 const input = document.getElementById("message-input");
 
 inputHistory.initInputHistory(input);
-referenceFocus.setupReferenceFocus();
+setupReplyFocus();
 
 form.addEventListener("submit", (e) => {
     e.preventDefault();

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -6,13 +6,13 @@ import messages from './modules/messages.js';
 import inputHistory from './modules/input.js';
 import notifications from './modules/notifications.js';
 import history from './modules/history.js';
-import { setupReplyFocus } from "./modules/reply.js";
+import reply from "./modules/reply.js";
 
 const form = document.getElementById("input-area");
 const input = document.getElementById("message-input");
 
 inputHistory.initInputHistory(input);
-setupReplyFocus();
+reply.setupReplyFocus();
 
 form.addEventListener("submit", (e) => {
     e.preventDefault();

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -6,11 +6,13 @@ import messages from './modules/messages.js';
 import inputHistory from './modules/input.js';
 import notifications from './modules/notifications.js';
 import history from './modules/history.js';
+import referenceFocus from './modules/referenceFocus.js';
 
 const form = document.getElementById("input-area");
 const input = document.getElementById("message-input");
 
 inputHistory.initInputHistory(input);
+referenceFocus.setupReferenceFocus();
 
 form.addEventListener("submit", (e) => {
     e.preventDefault();

--- a/src/static/modules/auth.js
+++ b/src/static/modules/auth.js
@@ -35,7 +35,12 @@ function updateUsernamePrefix() {
     if (!prefix) {
         prefix = document.createElement("span");
         prefix.id = "username-prefix";
-        form.insertBefore(prefix, input);
+        const wrapper = document.querySelector(".input-wrapper");
+        if (wrapper && wrapper.contains(input)) {
+            form.insertBefore(prefix, wrapper);
+        } else {
+            form.insertBefore(prefix, input);
+        }
     }
 
     if (username && loggedIn) {

--- a/src/static/modules/formatting.js
+++ b/src/static/modules/formatting.js
@@ -1,6 +1,6 @@
 import utils from './utils.js';
 
-function formatMessage(text) {
+function formatMessage(text, preserveRaw = false) {
     if (!text) return "";
 
     const urls = [];
@@ -14,32 +14,40 @@ function formatMessage(text) {
 
     processed = utils.escapeHTML(processed);
 
-    processed = processed.replace(/`(.*?)`/g, '<code>$1</code>');
-    processed = processed.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
-    processed = processed.replace(/__(.*?)__/g, '<strong>$1</strong>');
-    processed = processed.replace(/\*(.*?)\*/g, '<em>$1</em>');
-    processed = processed.replace(/_(.*?)_/g, '<em>$1</em>');
-    processed = processed.replace(/~~(.*?)~~/g, '<del>$1</del>');
-
-    processed = processed.replace(/(^|\s)#([A-zÀ-ú0-9_\-]+)/g, (match, prefix, channel) => {
-        return `${prefix}<a href="?${channel}">#${channel}</a>`;
-    });
-
-    processed = processed.replace(/(^|\s)@([A-zÀ-ú0-9_\-]+)/g, (match, prefix, user) => {
-        const color = utils.getUserColor(user);
-        return `${prefix}<span style="color: ${color}">@${user}</span>`;
-    });
-
-    processed = processed.replace(/(^|\s)(\/[a-zA-Z0-9_\-]+)/g, (match, prefix, command) => {
-        return `${prefix}<span class="command">${command}</span>`;
-    });
-    
-    // Parse references <channel: date timeHM:timeS [user]>
+    // 1. References
     processed = processed.replace(/&lt;(#?[A-zÀ-ú0-9_\-]+):\s*(\d{4}-\d{2}-\d{2})\s*(\d{2}:\d{2}):(\d{2})\s*\[(.*?)\]&gt;/g, (match, channel, date, timeHM, timeS, user) => {
+        if (preserveRaw) {
+            return `<span style="color: #aaa; text-decoration: underline;">${match}</span>`;
+        }
         const userColor = utils.getUserColor(user);
         return `<span class="message-reference" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" style="cursor: pointer; text-decoration: underline; color: #aaa;" title="Click to focus message">«reply to <span style="color: ${userColor}">@${user}</span>»</span>`;
     });
 
+    // 2. Channels
+    processed = processed.replace(/(^|\s)#([A-zÀ-ú0-9_\-]+)(?![^<]*>)/g, (match, prefix, channel) => {
+        return `${prefix}<a href="?${channel}">#${channel}</a>`;
+    });
+
+    // 3. Mentions
+    processed = processed.replace(/(^|\s)@([A-zÀ-ú0-9_\-]+)(?![^<]*>)/g, (match, prefix, user) => {
+        const color = utils.getUserColor(user);
+        return `${prefix}<span style="color: ${color}">@${user}</span>`;
+    });
+
+    // 4. Commands
+    processed = processed.replace(/(^|\s)(\/[a-zA-Z0-9_\-]+)(?![^<]*>)/g, (match, prefix, command) => {
+        return `${prefix}<span class="command">${command}</span>`;
+    });
+
+    // 5. Markdown
+    processed = processed.replace(/`(.*?)`/g, preserveRaw ? '<code style="padding: 0;">`$1`</code>' : '<code>$1</code>');
+    processed = processed.replace(/\*\*(.*?)\*\*/g, preserveRaw ? '<strong>**$1**</strong>' : '<strong>$1</strong>');
+    processed = processed.replace(/__(.*?)__/g, preserveRaw ? '<strong>__$1__</strong>' : '<strong>$1</strong>');
+    processed = processed.replace(/\*(.*?)\*/g, preserveRaw ? '<em>*$1*</em>' : '<em>$1</em>');
+    processed = processed.replace(/_(.*?)_/g, preserveRaw ? '<em>_$1_</em>' : '<em>$1</em>');
+    processed = processed.replace(/~~(.*?)~~/g, preserveRaw ? '<del>~~$1~~</del>' : '<del>$1</del>');
+
+    // 6. URLs
     return processed.replace(/URLPLACEHOLDER(\d+)URL/g, (match, id) => {
         const url = urls[parseInt(id)];
         const escapedUrl = utils.escapeHTML(url);

--- a/src/static/modules/formatting.js
+++ b/src/static/modules/formatting.js
@@ -33,6 +33,11 @@ function formatMessage(text) {
     processed = processed.replace(/(^|\s)(\/[a-zA-Z0-9_\-]+)/g, (match, prefix, command) => {
         return `${prefix}<span class="command">${command}</span>`;
     });
+    
+    // Parse references <channel: date timeHM:timeS [user]>
+    processed = processed.replace(/&lt;(#?[A-zÀ-ú0-9_\-]+):\s*(\d{4}-\d{2}-\d{2})\s*(\d{2}:\d{2}):(\d{2})\s*\[(.*?)\]&gt;/g, (match, channel, date, timeHM, timeS, user) => {
+        return `<span class="message-reference" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" style="cursor: pointer; text-decoration: underline; color: #aaa;" title="Click to focus message">«reply to [${user}]»</span>`;
+    });
 
     return processed.replace(/URLPLACEHOLDER(\d+)URL/g, (match, id) => {
         const url = urls[parseInt(id)];

--- a/src/static/modules/formatting.js
+++ b/src/static/modules/formatting.js
@@ -36,7 +36,8 @@ function formatMessage(text) {
     
     // Parse references <channel: date timeHM:timeS [user]>
     processed = processed.replace(/&lt;(#?[A-zÀ-ú0-9_\-]+):\s*(\d{4}-\d{2}-\d{2})\s*(\d{2}:\d{2}):(\d{2})\s*\[(.*?)\]&gt;/g, (match, channel, date, timeHM, timeS, user) => {
-        return `<span class="message-reference" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" style="cursor: pointer; text-decoration: underline; color: #aaa;" title="Click to focus message">«reply to @${user}»</span>`;
+        const userColor = utils.getUserColor(user);
+        return `<span class="message-reference" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" style="cursor: pointer; text-decoration: underline; color: #aaa;" title="Click to focus message">«reply to <span style="color: ${userColor}">@${user}</span>»</span>`;
     });
 
     return processed.replace(/URLPLACEHOLDER(\d+)URL/g, (match, id) => {

--- a/src/static/modules/formatting.js
+++ b/src/static/modules/formatting.js
@@ -36,7 +36,7 @@ function formatMessage(text) {
     
     // Parse references <channel: date timeHM:timeS [user]>
     processed = processed.replace(/&lt;(#?[A-zÀ-ú0-9_\-]+):\s*(\d{4}-\d{2}-\d{2})\s*(\d{2}:\d{2}):(\d{2})\s*\[(.*?)\]&gt;/g, (match, channel, date, timeHM, timeS, user) => {
-        return `<span class="message-reference" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" style="cursor: pointer; text-decoration: underline; color: #aaa;" title="Click to focus message">«reply to [${user}]»</span>`;
+        return `<span class="message-reference" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" style="cursor: pointer; text-decoration: underline; color: #aaa;" title="Click to focus message">«reply to @${user}»</span>`;
     });
 
     return processed.replace(/URLPLACEHOLDER(\d+)URL/g, (match, id) => {

--- a/src/static/modules/input.js
+++ b/src/static/modules/input.js
@@ -1,3 +1,5 @@
+import formatting from './formatting.js';
+
 const messageHistory = [];
 let historyIndex = 0;
 let currentDraft = "";
@@ -39,7 +41,81 @@ function addMessageToHistory(message) {
     currentDraft = "";
 }
 
+function setupInputOverlay(inputElement) {
+    const wrapper = document.createElement('div');
+    wrapper.style.position = 'relative';
+    wrapper.style.flex = '1';
+    wrapper.style.display = 'flex';
+    wrapper.style.alignItems = 'stretch';
+    wrapper.className = 'input-wrapper';
+
+    const overlay = document.createElement('div');
+    overlay.className = 'input-overlay';
+    overlay.style.position = 'absolute';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.right = '0';
+    overlay.style.bottom = '0';
+    overlay.style.pointerEvents = 'none';
+    overlay.style.whiteSpace = 'pre';
+    overlay.style.overflow = 'hidden';
+    overlay.style.padding = '10px';
+    overlay.style.fontFamily = 'monospace';
+    overlay.style.fontSize = '12px';
+    overlay.style.color = '#fff';
+    overlay.style.boxSizing = 'border-box';
+    overlay.style.border = '1px solid transparent';
+    overlay.style.lineHeight = 'normal';
+
+    inputElement.parentNode.insertBefore(wrapper, inputElement);
+    wrapper.appendChild(overlay);
+    wrapper.appendChild(inputElement);
+
+    inputElement.style.color = 'transparent';
+    inputElement.style.caretColor = '#fff';
+    inputElement.style.background = 'transparent';
+    inputElement.style.position = 'relative';
+    inputElement.style.zIndex = '2';
+    
+    wrapper.style.background = '#333';
+    wrapper.style.border = '1px solid #555';
+    inputElement.style.border = 'none';
+    inputElement.style.outline = 'none';
+    inputElement.style.margin = '0';
+    inputElement.style.width = '100%';
+
+    function updateOverlay() {
+        const text = inputElement.value;
+        const html = formatting.formatMessage(text, true);
+
+        overlay.innerHTML = html;
+        
+        // Sync scroll
+        overlay.scrollLeft = inputElement.scrollLeft;
+    }
+
+    inputElement.addEventListener('input', updateOverlay);
+    inputElement.addEventListener('scroll', () => {
+        overlay.scrollLeft = inputElement.scrollLeft;
+    });
+    
+    // Also update when value is changed programmatically
+    const originalDescriptor = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+    Object.defineProperty(inputElement, 'value', {
+        get: function() {
+            return originalDescriptor.get.call(this);
+        },
+        set: function(val) {
+            originalDescriptor.set.call(this, val);
+            updateOverlay();
+        }
+    });
+
+    updateOverlay();
+}
+
 export default {
     initInputHistory,
-    addMessageToHistory
+    addMessageToHistory,
+    setupInputOverlay
 };

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -93,12 +93,18 @@ function createMessageElement(date, timeHM, timeS, from, content) {
     timeSpan.title = "Click to reply";
     timeSpan.addEventListener("click", () => {
         const msgInput = document.getElementById("message-input");
-        const channel = auth.getChannel ? auth.getChannel() : "#general";
+        let channel = window.location.search.substring(1);
+        if (!channel) {
+            channel = "#general";
+        } else if (!channel.startsWith("#")) {
+            channel = "#" + channel;
+        }
+
         const reference = `<${channel}: ${date} ${timeHM}:${timeS} [${from}]>`;
         
-        if (!msgInput.value.includes(reference)) {
-           msgInput.value = `${reference} ` + msgInput.value;
-        }
+        // Remove existing reference if any
+        let currentText = msgInput.value.replace(/<[^>]+>\s*/g, '');
+        msgInput.value = `${reference} ${currentText}`;
         msgInput.focus();
     });
 

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -89,6 +89,18 @@ function createMessageElement(date, timeHM, timeS, from, content) {
     const timeSpan = document.createElement("span");
     timeSpan.className = "timestamp";
     timeSpan.innerHTML = `${timeHM}<span class="timestamp-seconds">:${timeS}</span>`;
+    timeSpan.style.cursor = "pointer";
+    timeSpan.title = "Click to reply";
+    timeSpan.addEventListener("click", () => {
+        const msgInput = document.getElementById("message-input");
+        const channel = auth.getChannel ? auth.getChannel() : "#general";
+        const reference = `<${channel}: ${date} ${timeHM}:${timeS} [${from}]>`;
+        
+        if (!msgInput.value.includes(reference)) {
+           msgInput.value = `${reference} ` + msgInput.value;
+        }
+        msgInput.focus();
+    });
 
     const fromSpan = document.createElement("span");
     fromSpan.textContent = `[${from}]: `;

--- a/src/static/modules/network.js
+++ b/src/static/modules/network.js
@@ -60,12 +60,12 @@ function connect(onMessageCallback) {
     
     if (search) {
         if (search.includes("=")) {
-            wsUrl += `?${search}&tz=${tzOffset}`;
+            wsUrl += `?${search}&tz=${tzOffset}&expand_reply=false`;
         } else {
-            wsUrl += `?channel=${search}&tz=${tzOffset}`;
+            wsUrl += `?channel=${search}&tz=${tzOffset}&expand_reply=false`;
         }
     } else {
-        wsUrl += `?tz=${tzOffset}`;
+        wsUrl += `?tz=${tzOffset}&expand_reply=false`;
     }
     ws = new WebSocket(wsUrl);
 

--- a/src/static/modules/network.js
+++ b/src/static/modules/network.js
@@ -57,15 +57,16 @@ function connect(onMessageCallback) {
     
     // Calculate the timezone offset in hours (e.g. UTC-3 is -3)
     const tzOffset = -(new Date().getTimezoneOffset() / 60);
+    const default_query_params = `tz=${tzOffset}&expand_reply=false`;
     
     if (search) {
         if (search.includes("=")) {
-            wsUrl += `?${search}&tz=${tzOffset}&expand_reply=false`;
+            wsUrl += `?${search}&${default_query_params}`;
         } else {
-            wsUrl += `?channel=${search}&tz=${tzOffset}&expand_reply=false`;
+            wsUrl += `?channel=${search}&${default_query_params}`;
         }
     } else {
-        wsUrl += `?tz=${tzOffset}&expand_reply=false`;
+        wsUrl += `?${default_query_params}`;
     }
     ws = new WebSocket(wsUrl);
 

--- a/src/static/modules/referenceFocus.js
+++ b/src/static/modules/referenceFocus.js
@@ -1,0 +1,48 @@
+export function setupReferenceFocus() {
+    document.getElementById('chat').addEventListener('click', (e) => {
+        if (e.target && e.target.classList.contains('message-reference')) {
+            const date = e.target.dataset.date;
+            const timeHM = e.target.dataset.timeHm;
+            const timeS = e.target.dataset.timeS;
+            const from = e.target.dataset.from;
+            
+            // Find the message in the DOM
+            const chat = document.getElementById('chat');
+            const messages = chat.querySelectorAll('.message');
+            
+            let matchedMessage = null;
+            
+            for (const msg of messages) {
+                if (msg.dataset.date === date && 
+                    msg.dataset.timeHm === timeHM && 
+                    msg.dataset.timeS === timeS && 
+                    msg.dataset.from === from) {
+                    matchedMessage = msg;
+                    break;
+                }
+                
+                // Fallback: sometimes timeS may not perfectly match if it wasn't tracked precisely,
+                // try to match with date, hm and user
+                if (!matchedMessage && 
+                    msg.dataset.date === date && 
+                    msg.dataset.timeHm === timeHM && 
+                    msg.dataset.from === from) {
+                    matchedMessage = msg;
+                }
+            }
+            
+            if (matchedMessage) {
+                matchedMessage.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                
+                matchedMessage.classList.add('focused');
+                
+                // Remove the class after animation completes so it can be triggered again
+                setTimeout(() => {
+                    matchedMessage.classList.remove('focused');
+                }, 3000);
+            }
+        }
+    });
+}
+
+export default { setupReferenceFocus };

--- a/src/static/modules/reply.js
+++ b/src/static/modules/reply.js
@@ -1,41 +1,41 @@
-export function setupReplyFocus() {
+function setupReplyFocus() {
     document.getElementById('chat').addEventListener('click', (e) => {
         if (e.target && e.target.classList.contains('message-reference')) {
             const date = e.target.dataset.date;
             const timeHM = e.target.dataset.timeHm;
             const timeS = e.target.dataset.timeS;
             const from = e.target.dataset.from;
-            
+
             // Find the message in the DOM
             const chat = document.getElementById('chat');
             const messages = chat.querySelectorAll('.message');
-            
+
             let matchedMessage = null;
-            
+
             for (const msg of messages) {
-                if (msg.dataset.date === date && 
-                    msg.dataset.timeHm === timeHM && 
-                    msg.dataset.timeS === timeS && 
+                if (msg.dataset.date === date &&
+                    msg.dataset.timeHm === timeHM &&
+                    msg.dataset.timeS === timeS &&
                     msg.dataset.from === from) {
                     matchedMessage = msg;
                     break;
                 }
-                
+
                 // Fallback: sometimes timeS may not perfectly match if it wasn't tracked precisely,
                 // try to match with date, hm and user
-                if (!matchedMessage && 
-                    msg.dataset.date === date && 
-                    msg.dataset.timeHm === timeHM && 
+                if (!matchedMessage &&
+                    msg.dataset.date === date &&
+                    msg.dataset.timeHm === timeHM &&
                     msg.dataset.from === from) {
                     matchedMessage = msg;
                 }
             }
-            
+
             if (matchedMessage) {
                 matchedMessage.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                
+
                 matchedMessage.classList.add('focused');
-                
+
                 // Remove the class after animation completes so it can be triggered again
                 setTimeout(() => {
                     matchedMessage.classList.remove('focused');
@@ -45,4 +45,4 @@ export function setupReplyFocus() {
     });
 }
 
-export default { setupReferenceFocus };
+export default { setupReplyFocus };

--- a/src/static/modules/reply.js
+++ b/src/static/modules/reply.js
@@ -1,10 +1,12 @@
-function setupReplyFocus() {
+export function setupReplyFocus() {
     document.getElementById('chat').addEventListener('click', (e) => {
-        if (e.target && e.target.classList.contains('message-reference')) {
-            const date = e.target.dataset.date;
-            const timeHM = e.target.dataset.timeHm;
-            const timeS = e.target.dataset.timeS;
-            const from = e.target.dataset.from;
+        // If we click inside the reference but not exactly on the element (like clicking the span inside)
+        const target = e.target.closest('.message-reference');
+        if (target) {
+            const date = target.dataset.date;
+            const timeHM = target.dataset.timeHm;
+            const timeS = target.dataset.timeS;
+            const from = target.dataset.from;
 
             // Find the message in the DOM
             const chat = document.getElementById('chat');
@@ -44,5 +46,3 @@ function setupReplyFocus() {
         }
     });
 }
-
-export default { setupReplyFocus };

--- a/src/static/modules/reply.js
+++ b/src/static/modules/reply.js
@@ -1,4 +1,4 @@
-export function setupReplyFocus() {
+function setupReplyFocus() {
     document.getElementById('chat').addEventListener('click', (e) => {
         // If we click inside the reference but not exactly on the element (like clicking the span inside)
         const target = e.target.closest('.message-reference');
@@ -46,3 +46,5 @@ export function setupReplyFocus() {
         }
     });
 }
+
+export default { setupReplyFocus };

--- a/src/static/modules/reply.js
+++ b/src/static/modules/reply.js
@@ -1,4 +1,4 @@
-export function setupReferenceFocus() {
+export function setupReplyFocus() {
     document.getElementById('chat').addEventListener('click', (e) => {
         if (e.target && e.target.classList.contains('message-reference')) {
             const date = e.target.dataset.date;

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -376,3 +376,13 @@ a:active {
                          var(--sb-track-color);
     }
 }
+
+/* Focused message highlight */
+.message.focused {
+    animation: highlightFade 3s forwards;
+}
+
+@keyframes highlightFade {
+    0% { background-color: rgba(255, 255, 255, 0.2); }
+    100% { background-color: transparent; }
+}

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -198,7 +198,7 @@ button:hover {
 }
 
 code {
-    background: #333;
+    background: #444;
     padding: 2px 4px;
     border-radius: 4px;
     font-family: monospace;

--- a/tests/integration.lisp
+++ b/tests/integration.lisp
@@ -27,7 +27,11 @@
 (defmacro with-websocket-client ((client messages-var &key additional-headers query-params) &body body)
   (let ((url (gensym))
         (connected (gensym)))
-    `(let* ((,url (format nil "ws://127.0.0.1:~a/ws~a" config:*websocket-port* (if ,query-params (concatenate 'string "?" ,query-params) "")))
+    `(let* ((,url (format nil "ws://127.0.0.1:~a/ws~a"
+                                 config:*websocket-port*
+                                 (if ,query-params
+                                     (concatenate 'string "?" ,query-params)
+                                     "")))
             (,client (make-client ,url :additional-headers ,additional-headers))
             (,connected nil)
             (,messages-var '()))

--- a/tests/unit.lisp
+++ b/tests/unit.lisp
@@ -41,7 +41,7 @@
   (let* ((message (server:make-message :from "@server"
                                        :content (format nil "line1~%~%xline2")
                                        :time (server:get-time)))
-         (message-string (server:formatted-message message)))
+         (message-string (server:formatted-message message :client nil)))
    (is equal
        3
        (count #\@ message-string :test #'char-equal))))


### PR DESCRIPTION
## Overview

This PR introduces a reply feature for the Web client, alongside server-side enhancements to support message formatting and citations. It also includes general refactoring and improvements to codebase tooling.

## Key Features & Changes

### Web Client Reply System
- **Message Hyperlinks & Mentions:** Implemented a new reply feature with message hyperlinks (`reply.js`). Added support for colorizing `@user` mentions inside reply references.
- **Improved Interaction:** Clicking on a reply reference now properly focuses the original message, even when interacting with the nested `@user` span.
- **Input Formatting Overlay:** Introduced an input overlay to provide visual formatting (like citations or styling) of the current message directly within the input field before it is sent.

### Server-side Enhancements
- **Client-Aware Formatters:** Refactored server formatter functions to take a `client` instance, allowing for more contextual message formatting (`formatter.lisp`, `commands.lisp`).
- **Multiline Citations:** Added support for multiline cited messages when `expand_reply` is enabled on the server side.

### Codebase & Tooling
- **Linting Target:** Added a new `make lint-fix` target to the `Makefile`.
- **Refactoring:** Applied automated lint fixes across the Lisp codebase, improving code consistency and styling.

## Changed Files (Overview)
- **Web Frontend:** `src/static/modules/reply.js` (new), `src/static/modules/input.js`, `src/static/modules/formatting.js`, `src/static/modules/messages.js`, `src/static/style.css`
- **Lisp Backend:** `src/server/commands.lisp`, `src/server/formatter.lisp`, `src/server/web.lisp`
- **Tooling:** `Makefile`


# Showcase

How to use: click in the timestamp to reply a message, the reply will have a reference "reply to <user>". If you click it again, will focus on it.

<img width="657" height="734" alt="Screenshot from 2026-04-29 14-59-02" src="https://github.com/user-attachments/assets/0d614322-2099-4163-9914-122257439c18" />
