### PR TITLE
feat(web): shareable message links

### DIFF
--- a/src/server/commands.lisp
+++ b/src/server/commands.lisp
@@ -268,18 +268,21 @@
             (> (server:message-universal-time m1)
                (server:message-universal-time m2))))))
 
-(define-command /log (client &key (depth "20") date-format global before after around &allow-other-keys)
+(define-command /log (client &key (depth "20") date-format global before after around reference &allow-other-keys)
   "/log shows the last messages sent to the server.
    DEPTH is optional number of messages frames from log
    GLOBAL is optional boolean to search across all channels
    BEFORE is optional ISO format datetime filter (e.g., 2026-02-22T14:30).
    AFTER is optional ISO format datetime filter (e.g., 2026-02-22T14:30).
-   AROUND is optional ISO format datetime filter (e.g., 2026-02-22T14:30)."
+   AROUND is optional ISO format datetime filter (e.g., 2026-02-22T14:30).
+   REFERENCE is optional message reference string."
   (declare (ignorable client))
   (let* ((parsed-depth (or (parse-integer (ensure-string depth) :junk-allowed t) 20))
          (before-time (server:parse-iso8601 (ensure-string before)))
          (after-time (server:parse-iso8601 (ensure-string after)))
-         (around-time (server:parse-iso8601 (ensure-string around)))
+         (ref-msg (when reference (server:get-message-by-reference-string (ensure-string reference))))
+         (around-time (or (when ref-msg (server:message-universal-time ref-msg))
+                          (server:parse-iso8601 (ensure-string around))))
          (filtered (filter-messages client :global global :before-time before-time :after-time after-time))
          (processed (if around-time
                         (get-messages-around filtered around-time parsed-depth)

--- a/src/server/commands.lisp
+++ b/src/server/commands.lisp
@@ -284,9 +284,16 @@
          (around-time (or (when ref-msg (server:message-universal-time ref-msg))
                           (server:parse-iso8601 (ensure-string around))))
          (filtered (filter-messages client :global global :before-time before-time :after-time after-time))
-         (processed (if around-time
-                        (get-messages-around filtered around-time parsed-depth)
-                        (subseq filtered 0 (min parsed-depth (length filtered)))))
+         (processed (cond
+                      (around-time
+                       (get-messages-around filtered around-time parsed-depth))
+                      ((and after-time (not before-time))
+                       ;; Paginating forward: 'filtered' is newest-first,
+                       ;; so the messages immediately following 'after' are at the end.
+                       (let ((len (length filtered)))
+                         (subseq filtered (max 0 (- len parsed-depth)) len)))
+                      (t
+                       (subseq filtered 0 (min parsed-depth (length filtered))))))
          (formatted (mapcar (lambda (m)
                               (server:formatted-message m :client client
                                                         :date-format date-format

--- a/src/server/formatter.lisp
+++ b/src/server/formatter.lisp
@@ -75,6 +75,13 @@
                   (string-equal (message-time-date-format m) (format nil "~a ~a" date time))))
            *messages-log*))
 
+(defun get-message-by-reference-string (ref-string)
+  "Find a message by its reference string <#channel: YYYY-MM-DD HH:MM:SS [user]>."
+  (cl-ppcre:register-groups-bind (channel date time user)
+      ("<(#?[A-zÀ-ú0-9_\\-]+):\\s*(\\d{4}-\\d{2}-\\d{2})\\s*(\\d{2}:\\d{2}:\\d{2})\\s*\\[(.*?)\\]>" ref-string)
+    (when (and channel date time user)
+      (get-message-by-reference channel date time user))))
+
 (defun expand-message-reply (raw-content)
   "Expand message references in the content."
   (let ((content-str raw-content))

--- a/src/server/package.lisp
+++ b/src/server/package.lisp
@@ -24,6 +24,7 @@
            #:*server-nickname*
            #:*raw-command-message*
            #:*uptime*
+           #:client
            #:client-name
            #:client-address
            #:client-time
@@ -45,6 +46,7 @@
            #:get-time
            #:format-time
            #:formatted-message
+           #:get-message-by-reference-string
            #:parse-iso8601
            #:message-universal-time
            #:search-message

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -11,6 +11,7 @@
     <div id="main">
       <button id="load-more-btn" class="hidden">⬆</button>
       <div id="chat"></div>
+      <button id="load-newer-btn" class="hidden">⬇</button>
       <div id="notifications"></div>
       <form id="input-area">
         <div id="autocomplete-popup" class="hidden"></div>

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -57,7 +57,8 @@ form.addEventListener("submit", (e) => {
             const parts = trimmed.split(/\s+/);
             if (parts.length > 1) {
                 const newChannel = parts[1].replace(/^#/, '');
-                const url = new URL(window.location);
+                const cleanPath = window.location.pathname.replace(/\/index\.html$/, '/');
+                const url = new URL(window.location.origin + cleanPath);
                 url.search = newChannel;
                 window.history.pushState({}, '', url);
                 updatePageTitle();

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -8,6 +8,15 @@ import notifications from './modules/notifications.js';
 import history from './modules/history.js';
 import reply from "./modules/reply.js";
 
+function updatePageTitle() {
+    let channel = window.location.search.substring(1).split('&')[0];
+    if (!channel || channel.includes('=')) {
+        channel = "general";
+    }
+    const channelName = channel.replace(/^#/, '');
+    document.title = `Lisp Chat Web: #${channelName}`;
+}
+
 const form = document.getElementById("input-area");
 const input = document.getElementById("message-input");
 
@@ -51,6 +60,7 @@ form.addEventListener("submit", (e) => {
                 const url = new URL(window.location);
                 url.search = newChannel;
                 window.history.pushState({}, '', url);
+                updatePageTitle();
             }
 
             input.value = "";
@@ -106,6 +116,7 @@ if (window.innerWidth > config.DESKTOP_MIN_WIDTH) {
     input.focus();
 }
 
+updatePageTitle();
 history.initHistoryLoading();
 autocomplete.initAutocomplete(input);
 network.connect(messages.addMessage);

--- a/src/static/modules/api.js
+++ b/src/static/modules/api.js
@@ -30,12 +30,15 @@ async function fetchCommand(command, kwargs = {}, provideSession = false) {
     return await response.json();
 }
 
-async function log(depth, before) {
-    return fetchCommand('log', {
+async function log(depth, before, after) {
+    const kwargs = {
         "depth": depth.toString(),
-        "before": before,
         "date-format": "date"
-    }, true);
+    };
+    if (before) kwargs.before = before;
+    if (after) kwargs.after = after;
+    
+    return fetchCommand('log', kwargs, true);
 }
 
 async function channels(all = true) {

--- a/src/static/modules/auth.js
+++ b/src/static/modules/auth.js
@@ -99,7 +99,7 @@ function performLogin(loginUsername) {
 
     if (messageRef) {
         history.setHistoricalContext(true);
-        network.getWs().send(`/log :reference "${messageRef}" :depth 30 :date-format date`);
+        network.getWs().send(`/log :reference "${messageRef}" :depth 20 :date-format date`);
     } else {
         history.setHistoricalContext(false);
         network.getWs().send(`/log :depth ${config.LOG_HISTORY_SIZE} :date-format date`);

--- a/src/static/modules/auth.js
+++ b/src/static/modules/auth.js
@@ -1,6 +1,7 @@
 import utils from './utils.js';
 import config from './config.js';
 import network from './network.js';
+import history from './history.js';
 
 let username = utils.getCookie("username") || "";
 let loggedIn = false;
@@ -92,7 +93,18 @@ function performLogin(loginUsername) {
     updateUsernamePrefix();
     hideLoginPanel();
     network.getWs().send(`/session`);
-    network.getWs().send(`/log :depth ${config.LOG_HISTORY_SIZE} :date-format date`);
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const messageRef = urlParams.get('message_ref');
+
+    if (messageRef) {
+        history.setHistoricalContext(true);
+        network.getWs().send(`/log :reference "${messageRef}" :depth 30 :date-format date`);
+    } else {
+        history.setHistoricalContext(false);
+        network.getWs().send(`/log :depth ${config.LOG_HISTORY_SIZE} :date-format date`);
+    }
+
     if (!network.getFetchUsersInterval()) {
         network.keepAliveWorker.postMessage('start');
         network.setFetchUsersInterval(true);

--- a/src/static/modules/formatting.js
+++ b/src/static/modules/formatting.js
@@ -20,7 +20,7 @@ function formatMessage(text, preserveRaw = false) {
             return `<span style="color: #aaa; text-decoration: underline;">${match}</span>`;
         }
         const userColor = utils.getUserColor(user);
-        return `<span class="message-reference" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" style="cursor: pointer; text-decoration: underline; color: #aaa;" title="Click to focus message">«reply to <span style="color: ${userColor}">@${user}</span>»</span>`;
+        return `<span class="message-reference" data-channel="${channel}" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" style="cursor: pointer; text-decoration: underline; color: #aaa;" title="Click to focus message">«reply to <span style="color: ${userColor}">@${user}</span>»</span>`;
     });
 
     // 2. Channels

--- a/src/static/modules/formatting.js
+++ b/src/static/modules/formatting.js
@@ -20,7 +20,7 @@ function formatMessage(text, preserveRaw = false) {
             return `<span style="color: #aaa; text-decoration: underline;">${match}</span>`;
         }
         const userColor = utils.getUserColor(user);
-        return `<span class="message-reference" data-channel="${channel}" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" style="cursor: pointer; text-decoration: underline; color: #aaa;" title="Click to focus message">«reply to <span style="color: ${userColor}">@${user}</span>»</span>`;
+        return `<span class="message-reference external" data-channel="${channel}" data-date="${date}" data-time-hm="${timeHM}" data-time-s="${timeS}" data-from="${user}" title="Click to open message link">«reply to <span style="color: ${userColor}">@${user}</span>»</span>`;
     });
 
     // 2. Channels

--- a/src/static/modules/history.js
+++ b/src/static/modules/history.js
@@ -123,8 +123,8 @@ function initHistoryLoading() {
                 const numMessagesBefore = messages.chat.querySelectorAll('.message').length;
                 
                 if (result.trim()) {
-                    // addMessage adds to bottom if prepend is false
-                    messages.addMessage(result, false); 
+                    // addMessage adds to bottom if prepend is false. Use forceNoScroll to prevent jumping to the end.
+                    messages.addMessage(result, false, true); 
                 }
                 
                 const numMessagesAfter = messages.chat.querySelectorAll('.message').length;

--- a/src/static/modules/history.js
+++ b/src/static/modules/history.js
@@ -4,19 +4,46 @@ import notifications from './notifications.js';
 import api from './api.js';
 
 const textButton = "⬆"
+const textNewerButton = "⬇"
 let hasReachedEnd = false;
+let isHistoricalContext = false;
+let hasReachedNewest = false;
+
+function setHistoricalContext(value) {
+    isHistoricalContext = value;
+    hasReachedNewest = false;
+    updateNewerButtonVisibility();
+}
+
+function updateNewerButtonVisibility() {
+    const loadNewerBtn = document.getElementById("load-newer-btn");
+    if (!loadNewerBtn) return;
+    
+    if (isHistoricalContext && !hasReachedNewest && messages.chat.scrollTop + messages.chat.clientHeight >= messages.chat.scrollHeight - 100) {
+        loadNewerBtn.classList.remove("hidden");
+    } else {
+        loadNewerBtn.classList.add("hidden");
+    }
+}
 
 function initHistoryLoading() {
     const loadMoreBtn = document.getElementById("load-more-btn");
+    const loadNewerBtn = document.getElementById("load-newer-btn");
+    if (loadNewerBtn) {
+        loadNewerBtn.textContent = textNewerButton;
+    }
+    
     if (!loadMoreBtn) return;
 
     messages.chat.addEventListener('scroll', () => {
-        if (hasReachedEnd) return;
-        if (messages.chat.scrollTop === 0 && messages.chat.scrollHeight > messages.chat.clientHeight) {
-            loadMoreBtn.classList.remove("hidden");
-        } else {
-            loadMoreBtn.classList.add("hidden");
+        if (!hasReachedEnd) {
+            if (messages.chat.scrollTop === 0 && messages.chat.scrollHeight > messages.chat.clientHeight) {
+                loadMoreBtn.classList.remove("hidden");
+            } else {
+                loadMoreBtn.classList.add("hidden");
+            }
         }
+        updateNewerButtonVisibility();
     });
 
     let isLoadingHistory = false;
@@ -63,10 +90,65 @@ function initHistoryLoading() {
         isLoadingHistory = false;
         loadMoreBtn.textContent = textButton;
     });
+
+    let isLoadingNewer = false;
+    if (loadNewerBtn) {
+        loadNewerBtn.addEventListener('click', async () => {
+            if (isLoadingNewer || hasReachedNewest) return;
+            isLoadingNewer = true;
+            
+            const newestMsg = messages.chat.querySelectorAll('.message');
+            const lastMsg = newestMsg[newestMsg.length - 1];
+            
+            if (!lastMsg) {
+                isLoadingNewer = false;
+                return;
+            }
+
+            const date = lastMsg.dataset.date;
+            const timeHm = lastMsg.dataset.timeHm;
+            const timeS = lastMsg.dataset.timeS;
+
+            if (!date || !timeHm || !timeS) {
+                isLoadingNewer = false;
+                return;
+            }
+            const isoDate = `${date}T${timeHm}:${timeS}`;
+
+            try {
+                // Fetch messages *after* the current newest message.
+                const data = await api.log(config.LOG_HISTORY_SIZE, undefined, isoDate);
+                const result = data.result || "";
+                
+                const numMessagesBefore = messages.chat.querySelectorAll('.message').length;
+                
+                if (result.trim()) {
+                    // addMessage adds to bottom if prepend is false
+                    messages.addMessage(result, false); 
+                }
+                
+                const numMessagesAfter = messages.chat.querySelectorAll('.message').length;
+                if (numMessagesBefore === numMessagesAfter) {
+                    hasReachedNewest = true;
+                    isHistoricalContext = false; // We reached the end, no longer historical.
+                    updateNewerButtonVisibility();
+                    notifications.showNotification("You are now viewing the latest messages.");
+                }
+            } catch (e) {
+                console.error("Failed to load newer messages", e);
+            }
+
+            isLoadingNewer = false;
+            updateNewerButtonVisibility();
+        });
+    }
 }
 
 function resetReachedEnd() {
     hasReachedEnd = false;
+    isHistoricalContext = false;
+    hasReachedNewest = false;
+    updateNewerButtonVisibility();
 }
 
-export default { initHistoryLoading, resetReachedEnd };
+export default { initHistoryLoading, resetReachedEnd, setHistoricalContext };

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -304,7 +304,7 @@ function addRawMessage(line, anchor) {
     insertMessageNode(div, anchor);
 }
 
-function addMessage(text, prepend = false) {
+function addMessage(text, prepend = false, forceNoScroll = false) {
     const isAtBottom = checkChatIsAtBottom();
     const linesArray = text.split(/\r?\n/);
     let anchor = null;
@@ -330,7 +330,7 @@ function addMessage(text, prepend = false) {
 
     if (prepend && chat.scrollHeight > previousScrollHeight) {
         chat.scrollTop += chat.scrollHeight - previousScrollHeight;
-    } else if (isAtBottom && !prepend) {
+    } else if (isAtBottom && !prepend && !forceNoScroll) {
         chat.scrollTop = chat.scrollHeight;
     }
 }

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -98,9 +98,21 @@ function createMessageElement(date, timeHM, timeS, from, content) {
     if (!channel || channel.includes('=')) {
         channel = "general";
     }
-    const reference = `<#${channel.replace('#', '')}: ${date} ${timeHM}:${timeS} [${from}]>`;
+
+    let refChannel = channel.replace('#', '');
+    let refFrom = from;
+
+    if (refFrom.startsWith("search:")) {
+        refFrom = refFrom.substring(7);
+    } else if (refFrom.startsWith("#") && refFrom.includes(":")) {
+        const colonIndex = refFrom.indexOf(":");
+        refChannel = refFrom.substring(1, colonIndex);
+        refFrom = refFrom.substring(colonIndex + 1);
+    }
+
+    const reference = `<#${refChannel}: ${date} ${timeHM}:${timeS} [${refFrom}]>`;
     const url = new URL(window.location.origin + window.location.pathname);
-    url.searchParams.set('channel', channel.replace('#', ''));
+    url.searchParams.set('channel', refChannel);
     url.searchParams.set('message_ref', reference);
     timeLink.href = url.toString();
 

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -238,9 +238,32 @@ function processStructuredMessage(line, match, anchor, prepend) {
         if (refMatch) {
             const [_, refChannel, refDate, refTimeHM, refTimeS, refFrom] = refMatch;
             if (effectiveDate === refDate && timeHM === refTimeHM && timeS === refTimeS && from === refFrom) {
-                div.classList.add('focused');
+                div.classList.add('shared-focus');
                 setTimeout(() => div.scrollIntoView({ behavior: 'smooth', block: 'center' }), 100);
-                setTimeout(() => div.classList.remove('focused'), 3000);
+                
+                // Remove focus on interaction
+                const removeFocus = () => {
+                    div.classList.remove('shared-focus');
+                    chat.removeEventListener('scroll', removeFocus);
+                    chat.removeEventListener('click', removeFocus);
+                    const msgInput = document.getElementById('message-input');
+                    if (msgInput) {
+                        msgInput.removeEventListener('input', removeFocus);
+                        msgInput.removeEventListener('keydown', removeFocus);
+                    }
+                };
+
+                // Add listeners after a short delay so the initial scroll doesn't trigger it
+                setTimeout(() => {
+                    chat.addEventListener('scroll', removeFocus, { once: true });
+                    chat.addEventListener('click', removeFocus, { once: true });
+                    const msgInput = document.getElementById('message-input');
+                    if (msgInput) {
+                        msgInput.addEventListener('input', removeFocus, { once: true });
+                        msgInput.addEventListener('keydown', removeFocus, { once: true });
+                    }
+                }, 1000);
+
                 // Clear message_ref from URL after first match to avoid re-triggering if new messages arrive
                 const newUrl = new URL(window.location);
                 newUrl.searchParams.delete('message_ref');

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -277,7 +277,11 @@ function processStructuredMessage(line, match, anchor, prepend) {
 
                 // Clear message_ref from URL after first match to avoid re-triggering if new messages arrive
                 const newUrl = new URL(window.location);
-                newUrl.searchParams.delete('message_ref');
+                let urlChannel = window.location.search.substring(1).split('&')[0];
+                if (!urlChannel || urlChannel.includes('=')) {
+                    urlChannel = refChannel.replace('#', '');
+                }
+                newUrl.search = `?${urlChannel}`;
                 window.history.replaceState({}, '', newUrl);
             }
         }

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -5,6 +5,7 @@ import notifications from './notifications.js';
 import users from './users.js';
 import auth from './auth.js';
 import network from './network.js';
+import reply from './reply.js';
 
 const chat = document.getElementById("chat");
 
@@ -333,6 +334,11 @@ function addMessage(text, prepend = false, forceNoScroll = false) {
     } else if (isAtBottom && !prepend && !forceNoScroll) {
         chat.scrollTop = chat.scrollHeight;
     }
+    
+    // Defer updating reference states so it doesn't block rendering
+    setTimeout(() => {
+        reply.updateReplyReferenceStates();
+    }, 10);
 }
 
 export default { chat, clearMessages, checkChatIsAtBottom, addMessage };

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -111,7 +111,8 @@ function createMessageElement(date, timeHM, timeS, from, content) {
     }
 
     const reference = `<#${refChannel}: ${date} ${timeHM}:${timeS} [${refFrom}]>`;
-    const url = new URL(window.location.origin + window.location.pathname);
+    const cleanPath = window.location.pathname.replace(/\/index\.html$/, '/');
+    const url = new URL(window.location.origin + cleanPath);
     url.search = `?${refChannel}&message_ref=${encodeURIComponent(reference)}`;
     timeLink.href = url.toString();
 
@@ -276,7 +277,8 @@ function processStructuredMessage(line, match, anchor, prepend) {
                 }, 1000);
 
                 // Clear message_ref from URL after first match to avoid re-triggering if new messages arrive
-                const newUrl = new URL(window.location);
+                const cleanPath = window.location.pathname.replace(/\/index\.html$/, '/');
+                const newUrl = new URL(window.location.origin + cleanPath);
                 let urlChannel = window.location.search.substring(1).split('&')[0];
                 if (!urlChannel || urlChannel.includes('=')) {
                     urlChannel = refChannel.replace('#', '');

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -86,21 +86,27 @@ function createMessageElement(date, timeHM, timeS, from, content) {
     div.dataset.timeS = timeS;
     div.dataset.from = from;
 
-    const timeSpan = document.createElement("span");
-    timeSpan.className = "timestamp";
-    timeSpan.innerHTML = `${timeHM}<span class="timestamp-seconds">:${timeS}</span>`;
-    timeSpan.style.cursor = "pointer";
-    timeSpan.title = "Click to reply";
-    timeSpan.addEventListener("click", () => {
-        const msgInput = document.getElementById("message-input");
-        let channel = window.location.search.substring(1);
-        if (!channel) {
-            channel = "#general";
-        } else if (!channel.startsWith("#")) {
-            channel = "#" + channel;
-        }
+    const timeLink = document.createElement("a");
+    timeLink.className = "timestamp";
+    timeLink.innerHTML = `${timeHM}<span class="timestamp-seconds">:${timeS}</span>`;
+    timeLink.style.cursor = "pointer";
+    timeLink.style.textDecoration = "none";
+    timeLink.style.color = "inherit";
+    timeLink.title = "Click to reply / Right click to copy link";
+    
+    let channel = window.location.search.substring(1).split('&')[0];
+    if (!channel || channel.includes('=')) {
+        channel = "general";
+    }
+    const reference = `<#${channel.replace('#', '')}: ${date} ${timeHM}:${timeS} [${from}]>`;
+    const url = new URL(window.location.origin + window.location.pathname);
+    url.searchParams.set('channel', channel.replace('#', ''));
+    url.searchParams.set('message_ref', reference);
+    timeLink.href = url.toString();
 
-        const reference = `<${channel}: ${date} ${timeHM}:${timeS} [${from}]>`;
+    timeLink.addEventListener("click", (e) => {
+        e.preventDefault();
+        const msgInput = document.getElementById("message-input");
         
         // Remove existing reference if any
         let currentText = msgInput.value.replace(/<[^>]+>\s*/g, '');
@@ -117,7 +123,7 @@ function createMessageElement(date, timeHM, timeS, from, content) {
     contentSpan.dataset.rawContent = content;
     contentSpan.innerHTML = formatting.formatMessage(content);
 
-    div.appendChild(timeSpan);
+    div.appendChild(timeLink);
     div.appendChild(fromSpan);
     div.appendChild(contentSpan);
 
@@ -223,6 +229,25 @@ function processStructuredMessage(line, match, anchor, prepend) {
     const div = createMessageElement(effectiveDate, timeHM, timeS, from, content);
 
     insertMessageNode(div, anchor);
+
+    // Check if this message is the one referenced in the URL
+    const urlParams = new URLSearchParams(window.location.search);
+    const messageRef = urlParams.get('message_ref');
+    if (messageRef) {
+        const refMatch = messageRef.match(/<(#?[A-zÀ-ú0-9_\-]+):\s*(\d{4}-\d{2}-\d{2})\s*(\d{2}:\d{2}):(\d{2})\s*\[(.*?)\]>/);
+        if (refMatch) {
+            const [_, refChannel, refDate, refTimeHM, refTimeS, refFrom] = refMatch;
+            if (effectiveDate === refDate && timeHM === refTimeHM && timeS === refTimeS && from === refFrom) {
+                div.classList.add('focused');
+                setTimeout(() => div.scrollIntoView({ behavior: 'smooth', block: 'center' }), 100);
+                setTimeout(() => div.classList.remove('focused'), 3000);
+                // Clear message_ref from URL after first match to avoid re-triggering if new messages arrive
+                const newUrl = new URL(window.location);
+                newUrl.searchParams.delete('message_ref');
+                window.history.replaceState({}, '', newUrl);
+            }
+        }
+    }
 }
 
 function addRawMessage(line, anchor) {

--- a/src/static/modules/messages.js
+++ b/src/static/modules/messages.js
@@ -112,8 +112,7 @@ function createMessageElement(date, timeHM, timeS, from, content) {
 
     const reference = `<#${refChannel}: ${date} ${timeHM}:${timeS} [${refFrom}]>`;
     const url = new URL(window.location.origin + window.location.pathname);
-    url.searchParams.set('channel', refChannel);
-    url.searchParams.set('message_ref', reference);
+    url.search = `?${refChannel}&message_ref=${encodeURIComponent(reference)}`;
     timeLink.href = url.toString();
 
     timeLink.addEventListener("click", (e) => {

--- a/src/static/modules/network.js
+++ b/src/static/modules/network.js
@@ -52,22 +52,25 @@ function connect(onMessageCallback) {
     }
 
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    const search = window.location.search.substring(1);
     let wsUrl = `${protocol}//${window.location.host}/ws`;
     
     // Calculate the timezone offset in hours (e.g. UTC-3 is -3)
     const tzOffset = -(new Date().getTimezoneOffset() / 60);
-    const default_query_params = `tz=${tzOffset}&expand_reply=false`;
     
-    if (search) {
-        if (search.includes("=")) {
-            wsUrl += `?${search}&${default_query_params}`;
-        } else {
-            wsUrl += `?channel=${search}&${default_query_params}`;
-        }
-    } else {
-        wsUrl += `?${default_query_params}`;
+    let channel = window.location.search.substring(1).split('&')[0];
+    if (!channel || channel.includes('=')) {
+        channel = '';
     }
+
+    const wsParams = new URLSearchParams();
+    if (channel) {
+        wsParams.set('channel', channel);
+    }
+    wsParams.set('tz', tzOffset);
+    wsParams.set('expand_reply', 'false');
+    
+    wsUrl += `?${wsParams.toString()}`;
+    
     ws = new WebSocket(wsUrl);
 
     ws.onopen = () => {

--- a/src/static/modules/reply.js
+++ b/src/static/modules/reply.js
@@ -53,7 +53,8 @@ function setupReplyFocus() {
                 const refChannel = channel.replace('#', '');
                 const reference = `<#${refChannel}: ${date} ${timeHM}:${timeS} [${from}]>`;
                 
-                const url = new URL(window.location.origin + window.location.pathname);
+                const cleanPath = window.location.pathname.replace(/\/index\.html$/, '/');
+                const url = new URL(window.location.origin + cleanPath);
                 url.search = `?${refChannel}&message_ref=${encodeURIComponent(reference)}`;
                 window.location.href = url.toString();
             }

--- a/src/static/modules/reply.js
+++ b/src/static/modules/reply.js
@@ -1,3 +1,48 @@
+function updateReplyReferenceStates() {
+    const chat = document.getElementById('chat');
+    if (!chat) return;
+
+    const references = chat.querySelectorAll('.message-reference');
+    const messages = chat.querySelectorAll('.message');
+
+    // Create a fast lookup map for messages currently in the DOM
+    const messageMap = new Set();
+    for (const msg of messages) {
+        if (msg.dataset.date && msg.dataset.timeHm && msg.dataset.from) {
+            // Include seconds for exact match
+            if (msg.dataset.timeS) {
+                messageMap.add(`${msg.dataset.date}|${msg.dataset.timeHm}:${msg.dataset.timeS}|${msg.dataset.from}`);
+            }
+            // Add fallback match without seconds
+            messageMap.add(`${msg.dataset.date}|${msg.dataset.timeHm}|${msg.dataset.from}`);
+        }
+    }
+
+    for (const ref of references) {
+        const date = ref.dataset.date;
+        const timeHM = ref.dataset.timeHm;
+        const timeS = ref.dataset.timeS;
+        const from = ref.dataset.from;
+
+        const exactKey = `${date}|${timeHM}:${timeS}|${from}`;
+        const fallbackKey = `${date}|${timeHM}|${from}`;
+
+        if (messageMap.has(exactKey) || messageMap.has(fallbackKey)) {
+            if (ref.classList.contains('external')) {
+                ref.classList.remove('external');
+                ref.classList.add('local');
+                ref.title = "Click to focus message";
+            }
+        } else {
+            if (ref.classList.contains('local')) {
+                ref.classList.remove('local');
+                ref.classList.add('external');
+                ref.title = "Click to open message link";
+            }
+        }
+    }
+}
+
 function setupReplyFocus() {
     document.getElementById('chat').addEventListener('click', (e) => {
         // If we click inside the reference but not exactly on the element (like clicking the span inside)
@@ -62,4 +107,4 @@ function setupReplyFocus() {
     });
 }
 
-export default { setupReplyFocus };
+export default { setupReplyFocus, updateReplyReferenceStates };

--- a/src/static/modules/reply.js
+++ b/src/static/modules/reply.js
@@ -42,6 +42,21 @@ function setupReplyFocus() {
                 setTimeout(() => {
                     matchedMessage.classList.remove('focused');
                 }, 3000);
+            } else {
+                let channel = target.dataset.channel;
+                if (!channel) {
+                    channel = window.location.search.substring(1).split('&')[0];
+                    if (!channel || channel.includes('=')) {
+                        channel = "general";
+                    }
+                }
+                const refChannel = channel.replace('#', '');
+                const reference = `<#${refChannel}: ${date} ${timeHM}:${timeS} [${from}]>`;
+                
+                const url = new URL(window.location.origin + window.location.pathname);
+                url.searchParams.set('channel', refChannel);
+                url.searchParams.set('message_ref', reference);
+                window.location.href = url.toString();
             }
         }
     });

--- a/src/static/modules/reply.js
+++ b/src/static/modules/reply.js
@@ -54,8 +54,7 @@ function setupReplyFocus() {
                 const reference = `<#${refChannel}: ${date} ${timeHM}:${timeS} [${from}]>`;
                 
                 const url = new URL(window.location.origin + window.location.pathname);
-                url.searchParams.set('channel', refChannel);
-                url.searchParams.set('message_ref', reference);
+                url.search = `?${refChannel}&message_ref=${encodeURIComponent(reference)}`;
                 window.location.href = url.toString();
             }
         }

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -410,9 +410,21 @@ a:active {
     animation: highlightFade 3s forwards;
 }
 
-.message.shared-focus {
-    background-color: rgba(255, 255, 255, 0.2);
-    transition: background-color 0.5s;
+.message-reference {
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.message-reference.local {
+    color: #aaa;
+}
+
+.message-reference.external {
+    color: lightblue; /* same as a:link */
+}
+
+.message-reference.external:hover {
+    color: deepskyblue; /* same as a:hover */
 }
 
 @keyframes highlightFade {

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -410,6 +410,11 @@ a:active {
     animation: highlightFade 3s forwards;
 }
 
+.message.shared-focus {
+    background-color: rgba(255, 255, 255, 0.2);
+    transition: background-color 0.5s;
+}
+
 @keyframes highlightFade {
     0% { background-color: rgba(255, 255, 255, 0.2); }
     100% { background-color: transparent; }

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -53,7 +53,30 @@ body {
     background: rgba(60, 60, 60, 0.95);
 }
 
-#load-more-btn.hidden {
+#load-newer-btn {
+    position: absolute;
+    bottom: 60px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10;
+    border-radius: 20px;
+    padding: 3px 10px;
+    background: rgba(40, 40, 40, 0.95);
+    color: #eee;
+    border: 1px solid #555;
+    cursor: pointer;
+    font-size: 11px;
+    opacity: 0.9;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.6);
+    transition: background 0.2s, opacity 0.2s;
+}
+
+#load-newer-btn:hover {
+    background: rgba(60, 60, 60, 0.95);
+}
+
+#load-more-btn.hidden,
+#load-newer-btn.hidden {
     display: none;
 }
 
@@ -159,8 +182,13 @@ button:hover {
 }
 
 .timestamp {
-    color: #666;
+    color: #666 !important;
     margin-right: 4px;
+    text-decoration: none !important;
+}
+
+.timestamp:hover {
+    text-decoration: underline !important;
 }
 
 .date-divider {

--- a/tests/unit.lisp
+++ b/tests/unit.lisp
@@ -62,3 +62,36 @@
   (is string= "#general" (server:normalize-channel "#"))
   (is string= "#general" (server:normalize-channel "%23"))
   (is eq nil (server:normalize-channel nil)))
+
+(define-test message-references
+  :parent unit-tests
+  (server:reset-server)
+  (let* ((time (server:get-time))
+         (msg (server:make-message :from "user1" :content "hello" :channel "#general" :time time))
+         (date-str (server:message-time-date-format msg))
+         (ref-string (format nil "<#general: ~a [user1]>" date-str)))
+    (push msg server:*messages-log*)
+    (let ((found (server:get-message-by-reference-string ref-string)))
+      (true found)
+      (is string= "user1" (server:message-from found))
+      (is string= "hello" (server:message-content found)))))
+
+(define-test log-command-with-reference
+  :parent unit-tests
+  (server:reset-server)
+  (let ((client (server::make-client :active-channel "#general")))
+    (dotimes (i 50)
+      (push (server:make-message :from (format nil "user~a" i)
+                                 :content (format nil "msg ~a" i)
+                                 :channel "#general"
+                                 :time (server:get-time))
+            server:*messages-log*))
+    (let* ((mid-msg (nth 25 (reverse server:*messages-log*)))
+           (date-str (server:message-time-date-format mid-msg))
+           (ref-string (format nil "<#general: ~a [~a]>" date-str (server:message-from mid-msg)))
+           (result (lisp-chat/commands:call-command client (format nil "/log :reference \"~a\" :depth 10" ref-string))))
+      (true result)
+      ;; Result should contains about 10 messages around msg 25
+      (is equal 10 (length (server:split result :delimiterp (lambda (c) (char= c #\Newline)) :empty-seqs t))))))
+
+


### PR DESCRIPTION
Implements shareable message links for the web client.

### Features
* **Copy Link:** Users can now click the timestamp of a message (which now functions as a native link) to copy a shareable URL or right-click to natively 'Copy link address'. Normal click still triggers the reply feature.
* **Auto-scrolling & Persistent Focus:** Opening a shared link automatically fetches the message, scrolls it into view, and applies a persistent highlight (`.shared-focus`) that stays active until the user interacts with the chat (scrolling, clicking, or typing).
* **Load Newer Messages:** A new '⬇' button appears at the bottom of the chat when in a historical context, allowing the user to fetch newer messages sequentially until reaching the live edge.
* **Server-side support:** Updated the `/log` command to accept a `:reference` parameter, which parses the message reference and loads historical context around that exact message timestamp.

### Testing
* Added and updated unit tests for `get-message-by-reference-string` and `/log :reference` functionality. All tests pass.