### PR TITLE
feat: aggregate duplicated user list with superscript notation

### DIFF
--- a/src/static/modules/users.js
+++ b/src/static/modules/users.js
@@ -1,15 +1,36 @@
 import utils from './utils.js';
 
+function getSuperscript(num) {
+    const map = {
+        '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴',
+        '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹'
+    };
+    return String(num).split('').map(char => map[char] || char).join('');
+}
+
 function updateUserList(usersString) {
     const userList = document.getElementById("user-list");
     if (!userList) return;
 
     const users = usersString.replace("users: ", "").split(",").map(u => u.trim()).filter(u => u.length > 0);
     userList.innerHTML = "";
+
+    const userCounts = {};
+    const order = [];
     users.forEach(user => {
+        if (!userCounts[user]) {
+            userCounts[user] = 0;
+            order.push(user);
+        }
+        userCounts[user]++;
+    });
+
+    order.forEach(user => {
+        const count = userCounts[user];
+        const displayName = count > 1 ? `${user}${getSuperscript(count)}` : user;
         const li = document.createElement("li");
         li.className = "user-item";
-        li.textContent = user;
+        li.textContent = displayName;
         li.style.color = utils.getUserColor(user);
         userList.appendChild(li);
     });


### PR DESCRIPTION
## Summary
When multiple devices log in under the same username, the web client's online users sidebar list displayed duplicate entries. 

This PR aggregates duplicate usernames in the frontend users list and displays them with a superscript notation indicating their device count (e.g., `lerax, lerax` → `lerax²`).

## Changes
- **`src/static/modules/users.js`**: 
  - Added a clean `getSuperscript` converter supporting standard and long/multi-digit subscript notations (`lerax¹²`).
  - Aggregated incoming users list while maintaining the original first-appearance order in the UI.
  - Extracted base usernames to call `utils.getUserColor()` so that different devices with superscript numbers retain the identical user brand color scheme (uninfluenced by the superscript indicator).