### PR TITLE
fix(web): prevent superscripts in autocomplete suggestions

### DIFF
--- a/src/static/modules/autocomplete.js
+++ b/src/static/modules/autocomplete.js
@@ -17,7 +17,7 @@ function getAutocompletePopup() {
 async function fetchAutoCompleteData(trigger) {
     if (trigger === '@') {
         const userList = document.getElementById("user-list");
-        return Array.from(userList.querySelectorAll('.user-item')).map(li => li.textContent);
+        return Array.from(userList.querySelectorAll('.user-item')).map(li => li.dataset.username || li.textContent);
     }
 
     if (autocompleteCache[trigger] !== null) return autocompleteCache[trigger];

--- a/src/static/modules/users.js
+++ b/src/static/modules/users.js
@@ -30,6 +30,7 @@ function updateUserList(usersString) {
         const displayName = count > 1 ? `${user}${getSuperscript(count)}` : user;
         const li = document.createElement("li");
         li.className = "user-item";
+        li.dataset.username = user;
         li.textContent = displayName;
         li.style.color = utils.getUserColor(user);
         userList.appendChild(li);


### PR DESCRIPTION
### Problem
When multiple users with identical names configured were rendered in the web user list (producing superscripts, e.g. ), the autocomplete  trigger read these strings directly from  text contents. This polluted the automatic text insertion with the superscript characters inside the input box.

### Solution
- Added  attribute to the list item () in  to store the original raw username.
- Updated  to read from  (falling back to  if missing) when gathering usernames.

This ensures that while the view looks pretty and displays superscript counters, the autocompleted output only contains clean, valid usernames.