### PR TITLE
fix: retrieve correct username from dataset for autocomplete to preserve color

### DIFF
--- a/src/static/modules/autocomplete.js
+++ b/src/static/modules/autocomplete.js
@@ -17,7 +17,7 @@ function getAutocompletePopup() {
 async function fetchAutoCompleteData(trigger) {
     if (trigger === '@') {
         const userList = document.getElementById("user-list");
-        return Array.from(userList.querySelectorAll('.user-item')).map(li => li.dataset.username || li.textContent);
+        return Array.from(userList.querySelectorAll('.user-item')).map(li => li.dataset.username);
     }
 
     if (autocompleteCache[trigger] !== null) return autocompleteCache[trigger];


### PR DESCRIPTION
This PR fixes a bug introduced in the previous autocomplete fix where the username in the autocomplete dropdown appeared with a superscript and had the wrong color. The fix ensures that we strictly retrieve `dataset.username` to calculate the correct user color without falling back to `textContent` carrying the superscript string.