### PR TITLE
feat(web): inline image preview for URLs with image+url syntax

### DIFF
--- a/src/static/modules/formatting.js
+++ b/src/static/modules/formatting.js
@@ -1,12 +1,29 @@
 import utils from './utils.js';
 
+// Image file extensions for auto-detection
+const IMAGE_EXTENSIONS = /\.(jpe?g|png|gif|webp|svg|bmp|ico|avif)(\?[^/\s]*)?$/i;
+
+function isImageUrl(url) {
+    return IMAGE_EXTENSIONS.test(url);
+}
+
 function formatMessage(text, preserveRaw = false) {
     if (!text) return "";
 
     const urls = [];
-    const urlPattern = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;\*]*[-A-Z0-9+&@#\/%=~_|])/ig;
+    const forcedImages = new Set();
+    const urlPattern = /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#/%?=~_|!:,.;\*]*[-A-Z0-9+&@#/%=~_|])/ig;
 
-    let processed = text.replace(urlPattern, (match) => {
+    // Pre-process image+URL syntax: strip the marker and flag as forced image
+    let processed = text.replace(/image\+((?:https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;\*]*[-A-Z0-9+&@#\/%=~_|])/ig, (match, url) => {
+        const id = urls.length;
+        urls.push(url);
+        forcedImages.add(id);
+        return `URLPLACEHOLDER${id}URL`;
+    });
+
+    // Extract remaining normal URLs
+    processed = processed.replace(urlPattern, (match) => {
         const id = urls.length;
         urls.push(match);
         return `URLPLACEHOLDER${id}URL`;
@@ -47,12 +64,17 @@ function formatMessage(text, preserveRaw = false) {
     processed = processed.replace(/_(.*?)_/g, preserveRaw ? '<em>_$1_</em>' : '<em>$1</em>');
     processed = processed.replace(/~~(.*?)~~/g, preserveRaw ? '<del>~~$1~~</del>' : '<del>$1</del>');
 
-    // 6. URLs
+    // 6. URLs (with optional inline image preview)
     return processed.replace(/URLPLACEHOLDER(\d+)URL/g, (match, id) => {
         const url = urls[parseInt(id)];
         const escapedUrl = utils.escapeHTML(url);
+        const shouldPreview = forcedImages.has(parseInt(id)) || isImageUrl(url);
+
+        if (shouldPreview && !preserveRaw) {
+            return `<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${escapedUrl}</a><img src="${escapedUrl}" alt="image preview" class="image-preview" loading="lazy" onerror="this.style.display='none'">`;
+        }
         return `<a href="${escapedUrl}" target="_blank" rel="noopener noreferrer">${escapedUrl}</a>`;
     });
 }
 
-export default { formatMessage };
+export default { formatMessage, isImageUrl };

--- a/src/static/style.css
+++ b/src/static/style.css
@@ -427,6 +427,19 @@ a:active {
     color: deepskyblue; /* same as a:hover */
 }
 
+/* Inline image preview */
+.image-preview {
+    display: block;
+    max-width: 400px;
+    max-height: 300px;
+    margin-top: 4px;
+    border: 1px solid #444;
+    border-radius: 4px;
+    cursor: pointer;
+    object-fit: contain;
+    background: #1a1a1a;
+}
+
 @keyframes highlightFade {
     0% { background-color: rgba(255, 255, 255, 0.2); }
     100% { background-color: transparent; }


### PR DESCRIPTION
## Summary

Adds inline image previews in the web client, respecting the minimalist style of lisp-chat.

Closes #148

# Showcase

![Screenshot_2026-07-21-00-22-22-50_3aea4af51f236e4932235fdada7d1643.jpg](https://github.com/user-attachments/assets/57a166a9-549f-4153-9ead-038153abc591)





## How it works

1. **Auto-detection**: URLs ending with image extensions (`.jpg`, `.png`, `.gif`, `.webp`, `.svg`, `.bmp`, `.ico`, `.avif`) are automatically rendered with an inline `<img>` preview below the clickable link.

2. **Forced preview via `image+URL`**: For URLs without a recognizable image extension (e.g. CDN URLs, dynamic endpoints), users can prefix the URL with `image+` to force the client to attempt a preview:
   ```
   image+https://nostr.build/i/avatar/12345
   ```
   The `image+` prefix is stripped from the rendered output — only the clickable URL and preview image are shown.

3. **Broken images**: `onerror` handler silently hides `<img>` elements that fail to load (404, CORS, non-image content), leaving just the clickable link.

4. **Reply references**: `preserveRaw` mode (used in reply quotes) disables previews to keep references compact.

## Design choices

- **No new dependencies**: Pure client-side change in `formatting.js` + CSS. No server-side modifications, no new npm/quicklisp packages.
- **Minimalist CSS**: `max-width: 400px`, `max-height: 300px`, dark background (`#1a1a1a`), 1px border, 4px border-radius — matches the existing dark theme.
- **Clickable URL preserved**: The URL link appears first, followed by the preview image in sequence. Users can still click the URL to open the full image in a new tab.
- **`loading="lazy"`**: Images load only when scrolled into viewport.

## Files changed

- `src/static/modules/formatting.js` — URL detection logic + `image+` prefix handling
- `src/static/style.css` — `.image-preview` CSS class

## Testing

- `make lint` ✅ (no new warnings)
- `make check` ✅ (125/125 tests pass)
- JS unit tests (Node.js mock) ✅ — validated auto-detection, forced preview, broken image handling, `preserveRaw` mode, mixed URLs, and query param edge cases
